### PR TITLE
Blank messages are no longer counted by spam muter

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -115,6 +115,12 @@
 			if(last_message_count >= SPAM_TRIGGER_AUTOMUTE_IDENTICAL)
 				src << "<span class='danger'>You have exceeded the spam filter limit for identical messages. An auto-mute was applied.</span>"
 				cmd_admin_mute(src, mute_type, 1)
+				var/admins_online = total_admins_active()
+				if(admins_online == 0)
+					src << "<span class='notice'>Your auto mute will be lifted in 5 minutes due to no admins being online.</span>"
+					sleep(3000)
+					cmd_admin_mute(src, mute_type, 0)
+					src << "<span class='notice'>Your auto mute has been lifted. You may now speak.</span>"
 				return 1
 			if(last_message_count >= SPAM_TRIGGER_WARNING_IDENTICAL)
 				src << "<span class='danger'>You are nearing the spam filter limit for identical messages.</span>"
@@ -122,11 +128,17 @@
 			last_message_count = 0
 			last_message = message
 
-		if((world.time - last_message_time) < SPAM_TRIGGER_AUTOMUTE_TIME)
+		if((world.time - last_message_time) < SPAM_TRIGGER_AUTOMUTE_TIME && message != null)
 			fast_message_count++
 			if(fast_message_count >= SPAM_TRIGGER_AUTOMUTE)
 				src << "<span class='danger'>You have exceeded the spam filter limit for messages in a short time period. An auto-mute was applied.</span>"
 				cmd_admin_mute(src, mute_type, 1)
+				var/admins_online = total_admins_active()
+				if(admins_online == 0)
+					src << "<span class='notice'>Your auto mute will be lifted in 5 minutes due to no admins being online.</span>"
+					sleep(3000)
+					cmd_admin_mute(src, mute_type, 0)
+					src << "<span class='notice'>Your auto mute has been lifted. You may now speak.</span>"
 				return 1
 			if(fast_message_count >= SPAM_TRIGGER_WARNING)
 				src << "<span class='danger'>You are nearing the spam filter limit for messages in a short time period.</span>"

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -110,7 +110,7 @@
 
 /client/proc/handle_spam_prevention(message, mute_type)
 	if(config.automute_on && !holder)
-		if(last_message == message)
+		if(last_message == message && message != null)
 			last_message_count++
 			if(last_message_count >= SPAM_TRIGGER_AUTOMUTE_IDENTICAL)
 				src << "<span class='danger'>You have exceeded the spam filter limit for identical messages. An auto-mute was applied.</span>"


### PR DESCRIPTION
Blank chat messages are no longer enforced by the spam system (dont know why this happens anyway)

#### Intent of your Pull Request

An issue with the spam system is you can spam say " and the spam system will mute you. I think this is a stupid issue and should be fixed. This is why I added a double check to see if the message is null or not.

##### Changelog

:cl:
rscadd: Blank messages are no longer counted as spam.
rscadd: Permamute is replaced with a 5 minute wait for the mute to be lifted (with no admins.)
/:cl:
