### PR TITLE
Removes the need for a vampire to get dusted

### DIFF
--- a/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
@@ -409,17 +409,10 @@
 	FreeAllVassals()
 
 	// Elders get Dusted
-	if (vamptitle)
-		owner.current.visible_message("<span class='warning'>[owner.current]'s skin crackles and dries, their skin and bones withering to dust. A hollow cry whips from what is now a sandy pile of remains.</span>", \
-			 "<span class='userdanger'>Your soul escapes your withering body as the abyss welcomes you to your Final Death.</span>", \
-			 "<span class='italics'>You hear a dry, crackling sound.</span>")
-		owner.current.dust()
-	// Fledglings get Gibbed
-	else
-		owner.current.visible_message("<span class='warning'>[owner.current]'s skin bursts forth in a spray of gore and detritus. A horrible cry echoes from what is now a wet pile of decaying meat.</span>", \
-			 "<span class='userdanger'>Your soul escapes your withering body as the abyss welcomes you to your Final Death.</span>", \
-			 "<span class='italics'>You hear a wet, bursting sound.</span>")
-		owner.current.gib()
+	owner.current.visible_message("<span class='warning'>[owner.current]'s skin crackles and dries, their skin and bones withering to dust. A hollow cry whips from what is now a sandy pile of remains.</span>", \
+		"<span class='userdanger'>Your soul escapes your withering body as the abyss welcomes you to your Final Death.</span>", \
+		"<span class='italics'>You hear a dry, crackling sound.</span>")
+	owner.current.dust()
 	playsound(owner.current.loc, 'sound/effects/tendril_destroyed.ogg', 40, 1)
 
 


### PR DESCRIPTION
This change removes the vampires need to get a vamp title which for some reason never works, and will always make them dust preventing them from being cloned, while also making a bit more sense. Even if they are rank 0 or 10, they should always dust.
