### PR TITLE
Fixes plasma fixation symptom in heal.dm

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -370,7 +370,7 @@
 		environment = M.loc.return_air()
 	if(environment)
 		gases = environment.gases
-		if(gases["plasma"] && gases["plasma"][MOLES] > gases["plasma"][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's enough plasma in the air to see
+		if(gases[/datum/gas/plasma] && gases[/datum/gas/plasma][MOLES] > gases[/datum/gas/plasma][GAS_META][META_GAS_MOLES_VISIBLE]) //if there's enough plasma in the air to see
 			. += power * 0.5
 	if(M.reagents.has_reagent(/datum/reagent/toxin/plasma, needs_metabolizing = TRUE))
 		. +=  power * 0.75


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes old code where standing in plasma gas while having a disease with the plasma fixation symptom no longer would activate the healing effect. 

Data structure returned by return_air() proc must have changed at some point, rendering this method  of checking for the presence of plasma gas outdated. This updates it to correctly check for said gas. I reported this bug on tg and requested they add breathing from internals as a condition to activate the symptom's healing effect as well. Expect another change to this file from the TG master branch in the coming weeks. This is just a temporary fix until they sort it out.


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes plasma fixation function as was originally intended.
## Changelog
:cl:
fix: Fixed code that was checking for an outdated data structure. Updated to new structure.


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
