### PR TITLE
Cryosting No Longer Stealthy

### DIFF
--- a/code/FulpstationCode/Fulp_changeling_mods/fulp_changeling_procs.dm
+++ b/code/FulpstationCode/Fulp_changeling_mods/fulp_changeling_procs.dm
@@ -1,0 +1,15 @@
+/datum/action/changeling/sting/proc/fulp_sting_feedback(mob/user, mob/target)
+	if(!target)
+		return FALSE
+	var/message = "<span class='notice'>We stealthily sting [target.name].</span>"
+
+	if(istype(src, /datum/action/changeling/sting/cryo))
+		to_chat(target, "<span class='warning'>You feel an icy cold prick.</span>")
+		message = "<span class='notice'>We sting [target.name] with our cryostinger.</span>"
+
+	else if(target.mind && target.mind.has_antag_datum(/datum/antagonist/changeling))
+		to_chat(target, "<span class='warning'>You feel a tiny prick.</span>")
+
+	to_chat(user, "[message]")
+
+	return TRUE

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -56,13 +56,9 @@
 	return 1
 
 /datum/action/changeling/sting/sting_feedback(mob/user, mob/target)
-	if(!target)
+	if(!fulp_sting_feedback(user, target)) //Fulpstation: Fulp_nerf_cryosting_stealth PR by Surrealistik Oct 2019
 		return
-	to_chat(user, "<span class='notice'>We stealthily sting [target.name].</span>")
-	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/changeling))
-		to_chat(target, "<span class='warning'>You feel a tiny prick.</span>")
 	return 1
-
 
 /datum/action/changeling/sting/transformation
 	name = "Transformation Sting"


### PR DESCRIPTION
### About The Pull Request
Changeling cryosting is no longer stealthy; the target will be given a notification of having been pricked.

### Why It's Good For The Game

Prevents lings from making risk free death injections of 100U+ frost oil dumps, including through restraints and disables, while giving the victim adequate time to get treatment/seek coffee.

### Changelog
🆑
add: Changeling cryosting no longer stealthy.
/🆑