### PR TITLE
Firing Pins for Mech Weapons

### DIFF
--- a/code/FulpstationCode/fulp_mech_firingpins/fulp_mech_firingpins.dm
+++ b/code/FulpstationCode/fulp_mech_firingpins/fulp_mech_firingpins.dm
@@ -27,21 +27,21 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon/proc/handle_pins()
 
-	var/mob/living/carbon/user = chassis.occupant
-	if(!user)
+	var/mob/user = chassis.occupant
+	if(!user) //Sanity check
+		return FALSE
+
+	if(!pin)
+		to_chat(user, "<span class='warning'>[src]'s trigger is locked. This weapon doesn't have a firing pin installed!</span>")
+		return FALSE
+
+	if(chassis.silicon_pilot) //We just need any kind of firing pin for AI/MMIs/Positronic Brains; they are always authorized.
 		return TRUE
 
-	if(pin)
+	if(pin.pin_auth(user) || (pin.obj_flags & EMAGGED))
+		return TRUE
 
-
-		if(pin.pin_auth(user) || (pin.obj_flags & EMAGGED))
-			return TRUE
-		else
-			pin.auth_fail(user)
-			return FALSE
-	else
-		to_chat(user, "<span class='warning'>[src]'s trigger is locked. This weapon doesn't have a firing pin installed!</span>")
-
+	pin.auth_fail(user)
 	return FALSE
 
 

--- a/code/FulpstationCode/fulp_mech_firingpins/fulp_mech_firingpins.dm
+++ b/code/FulpstationCode/fulp_mech_firingpins/fulp_mech_firingpins.dm
@@ -1,0 +1,92 @@
+#define MECHWEAPON_PIN_ADD_DELAY 3 SECONDS
+#define MECHWEAPON_PIN_REMOVAL_DELAY 5 SECONDS
+
+/obj/item/mecha_parts/mecha_equipment/weapon/Initialize()
+	. = ..()
+	if(pin)
+		pin = new pin(src)
+
+/obj/item/mecha_parts/mecha_equipment/weapon/Destroy()
+	. = ..()
+	if(isobj(pin))
+		QDEL_NULL(pin)
+
+/obj/item/mecha_parts/mecha_equipment/weapon/handle_atom_del(atom/A)
+	if(A == pin)
+		pin = null
+	return ..()
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/examine(mob/user)
+	. = ..()
+	if(pin)
+		. += "It has \a [pin] installed."
+	else
+		. += "It doesn't have a <b>firing pin</b> installed, and won't fire."
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/proc/handle_pins()
+
+	var/mob/living/carbon/user = chassis.occupant
+	if(!user)
+		return TRUE
+
+	if(pin)
+
+
+		if(pin.pin_auth(user) || (pin.obj_flags & EMAGGED))
+			return TRUE
+		else
+			pin.auth_fail(user)
+			return FALSE
+	else
+		to_chat(user, "<span class='warning'>[src]'s trigger is locked. This weapon doesn't have a firing pin installed!</span>")
+
+	return FALSE
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/attackby(obj/item/I, mob/user, params)
+	. = ..()
+	if(I.tool_behaviour == TOOL_SCREWDRIVER && pin)
+		visible_message("<span class='notice'>[user] begins to remove [src]'s firing pin...</span>",  \
+				"<span class='notice'>You begin to remove [src]'s firing pin...</span>", null, 3)
+		if(!do_after(user, MECHWEAPON_PIN_REMOVAL_DELAY, target = src))
+			return
+		QDEL_NULL(pin)
+		visible_message("<span class='warning'>[user] removes [src]'s firing pin. It can now fit a new pin, but the old one was destroyed in the process.</span>",  \
+				"<span class='warning'>You remove [src]'s firing pin, destroying it in the process.</span>",  \
+				null, 3)
+		playsound(src, pick('sound/items/screwdriver.ogg','sound/items/screwdriver2.ogg'), 30, TRUE)
+		return
+
+	if(istype(I, /obj/item/firing_pin))
+		var/obj/item/firing_pin/P = I
+		if(pin)
+			to_chat(user, "<span class='warning'>[src] already has a firing pin installed. You'll need to remove it with a <b>screwdriver</b>.</span>")
+			return
+		visible_message("<span class='notice'>[user] begins to install [P] into [src]...</span>",  \
+				"<span class='notice'>You begin to install [P] into [src]...</span>", null, 3)
+		if(!do_after(user, MECHWEAPON_PIN_ADD_DELAY, target = src))
+			return
+		visible_message("<span class='notice'>[user] installs [P] into [src]...</span>",  \
+				"<span class='notice'>You install [P] into [src]...</span>", null, 3)
+		playsound(src, 'sound/items/equip/toolbelt_equip.ogg', 30, TRUE)
+		P.mechgun_insert(user, src)
+
+
+/obj/item/firing_pin/proc/mechgun_insert(mob/living/user, obj/item/mecha_parts/mecha_equipment/weapon/G)
+	gun = G
+	forceMove(gun)
+	gun.pin = src
+	return
+
+/obj/mecha/combat/proc/unlock_mech_weapons() //Unlock all mech weapons
+	for(var/obj/item/I in equipment)
+		if(istype(I, /obj/item/mecha_parts/mecha_equipment/weapon/))
+			var/obj/item/mecha_parts/mecha_equipment/weapon/gun = I
+			gun.unlock_weapon()
+
+/obj/item/mecha_parts/mecha_equipment/weapon/proc/unlock_weapon() //For admin convenience/spawning unlocked weapons
+	if(pin)
+		qdel(pin)
+	pin = new /obj/item/firing_pin

--- a/code/FulpstationCode/fulp_mech_firingpins/fulp_mech_firingpins.dm
+++ b/code/FulpstationCode/fulp_mech_firingpins/fulp_mech_firingpins.dm
@@ -86,7 +86,18 @@
 			var/obj/item/mecha_parts/mecha_equipment/weapon/gun = I
 			gun.unlock_weapon()
 
+
 /obj/item/mecha_parts/mecha_equipment/weapon/proc/unlock_weapon() //For admin convenience/spawning unlocked weapons
 	if(pin)
 		qdel(pin)
 	pin = new /obj/item/firing_pin
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/Initialize()
+	. = ..()
+	if(!initial_firing_pin)
+		return
+	if(!ispath(initial_firing_pin, /obj/item/firing_pin))
+		log_mapping("[src] at [AREACOORD(src)] had an invalid firing pin type: [initial_firing_pin].")
+	else
+		pin = new initial_firing_pin(src)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -47,7 +47,7 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	ME.attach(src)
 	max_ammo()
-	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
+	unlock_mech_weapons() //FULP Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 /obj/mecha/combat/gygax/dark/add_cell(obj/item/stock_parts/cell/C=null)
 	if(C)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -47,6 +47,7 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	ME.attach(src)
 	max_ammo()
+	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 /obj/mecha/combat/gygax/dark/add_cell(obj/item/stock_parts/cell/C=null)
 	if(C)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -41,6 +41,7 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
 	max_ammo()
+	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 /obj/mecha/combat/marauder/seraph
 	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -41,7 +41,7 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
 	max_ammo()
-	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
+	unlock_mech_weapons() //FULP Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 /obj/mecha/combat/marauder/seraph
 	desc = "Heavy-duty, command-type exosuit. This is a custom model, utilized only by high-ranking military personnel."
@@ -69,7 +69,7 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
 	max_ammo()
-	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
+	unlock_mech_weapons() //FULP Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 /obj/mecha/combat/marauder/mauler
 	desc = "Heavy-duty, combat exosuit, developed off of the existing Marauder model."
@@ -94,6 +94,6 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
 	max_ammo()
-	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
+	unlock_mech_weapons() //FULP Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -69,6 +69,7 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
 	max_ammo()
+	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 /obj/mecha/combat/marauder/mauler
 	desc = "Heavy-duty, combat exosuit, developed off of the existing Marauder model."
@@ -93,5 +94,6 @@
 	ME = new /obj/item/mecha_parts/mecha_equipment/antiproj_armor_booster(src)
 	ME.attach(src)
 	max_ammo()
+	unlock_mech_weapons() //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 
 

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -34,7 +34,7 @@
 	if (targloc == curloc)
 		return 0
 
-	if (!handle_pins()) //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
+	if (!handle_pins()) //FULP Mech Weapon Firing Pins PR by Surrealistik Oct 2019
 		return FALSE
 
 	set_ready_state(0)

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -34,6 +34,9 @@
 	if (targloc == curloc)
 		return 0
 
+	if (!handle_pins()) //Mech Weapon Firing Pins PR by Surrealistik Oct 2019
+		return FALSE
+
 	set_ready_state(0)
 	for(var/i=1 to get_shot_amount())
 		var/obj/projectile/A = new projectile(curloc)

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -15,3 +15,13 @@
 	cost = 60
 	cant_discount = TRUE
 	illegal_tech = FALSE
+
+/datum/uplink_item/role_restricted/mech_firing_pin
+	name = "Concealed Weapon Bay (Mech Firing Pin Included)"
+	desc = "A handy firing pin that can only be installed into mech weapons. \
+			It also hides the equipped weapon from plain sight. \
+			Only one can fit on a mecha. \
+			This one comes complete with a handy firing pin that can only be installed into mech weapons"
+	item = /obj/item/storage/box/syndicate/bundle_mech
+	cost = 7 //So you cannot use it to get 3 unlocked mech weapons.
+	restricted_roles = list("Roboticist", "Research Director")

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -37,3 +37,15 @@
 
 /obj/item/clothing/suit/space/hardsuit
 	var/toggle_helmet_sound = 'sound/mecha/mechmove03.ogg'
+
+
+//*************************************************************
+//** Mech Weapon Firing Pins PR by Surrealistik Oct 2019 BEGINS
+//*************************************************************
+
+/obj/item/mecha_parts/mecha_equipment/weapon
+	var/obj/item/firing_pin/pin //standard firing pin for most guns
+
+//*************************************************************
+//** Mech Weapon Firing Pins PR by Surrealistik Oct 2019 ENDS
+//*************************************************************

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -45,6 +45,30 @@
 
 /obj/item/mecha_parts/mecha_equipment/weapon
 	var/obj/item/firing_pin/pin //standard firing pin for most guns
+	var/initial_firing_pin //If it is unlocked by default, this is the firing pin type the weapon uses
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/energy/plasma //Plasma cutter; more of a tool than a weapon
+	initial_firing_pin = /obj/item/firing_pin //standard firing pin for most guns
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/honker
+	initial_firing_pin = /obj/item/firing_pin //standard firing pin for most guns
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar
+	initial_firing_pin = /obj/item/firing_pin //standard firing pin for most guns
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/mousetrap_mortar
+	initial_firing_pin = /obj/item/firing_pin //standard firing pin for most guns
+
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/punching_glove
+	initial_firing_pin = /obj/item/firing_pin //standard firing pin for most guns
+
+/obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana
+	initial_firing_pin = null
 
 //*************************************************************
 //** Mech Weapon Firing Pins PR by Surrealistik Oct 2019 ENDS

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -70,6 +70,21 @@
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana
 	initial_firing_pin = null
 
+/obj/item/firing_pin/mech
+	name = "electronic mech firing pin"
+	desc = "A small authentication device, to be inserted into a firearm receiver to allow operation. NT safety regulations require all new designs to incorporate one. This one is specifically designed to be installed into mech and exosuit weaponry only."
+
+/obj/item/firing_pin/mech/afterattack(atom/target, mob/user, proximity_flag)
+	. = ..()
+	if(!proximity_flag)
+		return
+	if(istype(target, /obj/item/gun))
+		to_chat(user, "<span class='warning'>This firing pin is incompatible with guns and only be installed into mech weaponry!</span>")
+
+/obj/item/storage/box/syndicate/bundle_mech/PopulateContents()
+	new /obj/item/firing_pin/mech(src)
+	new /obj/item/mecha_parts/concealed_weapon_bay(src)
+
 //*************************************************************
 //** Mech Weapon Firing Pins PR by Surrealistik Oct 2019 ENDS
 //*************************************************************


### PR DESCRIPTION
## About The Pull Request

Mech weapons now need firing pins installed for them to work.  

To install a firing pin on a mech weapon, simply use the pin on it while it doesn't have one installed. To remove a pin, use a screwdriver on the weapon; this will destroy the pin.


## Why It's Good For The Game

Puts sane limits on the most powerful weapons in the game in line with their less powerful, but currently more restricted and secure hand-held weapons.


## Changelog
:cl:
add: Mech weapons now require firing pins in order to use. To install a firing pin on a mech weapon, simply use the pin on it while it doesn't have one installed. To remove a pin, use a screwdriver on the weapon; this will destroy the pin.
/:cl: