### PR TITLE
Security Record Permission Levels

### DIFF
--- a/code/FulpstationCode/improved_record_security/fulp_improved_record_security.dm
+++ b/code/FulpstationCode/improved_record_security/fulp_improved_record_security.dm
@@ -1,0 +1,37 @@
+#define SEC_RECORD_BAD_CLEARANCE "ACCESS DENIED: User ID has inadequate clearance."
+
+/obj/machinery/computer/secure_data/proc/check_input_clearance(mob/M, delete = FALSE)
+	if(!issilicon(M) && !IsAdminGhost(M)) //Silicons and AdminGhosts ignore access checks.
+		var/obj/item/card/id/I = M.get_idcard(TRUE)
+		if(!I)
+			return FALSE
+		req_access = list(ACCESS_SECURITY, ACCESS_ARMORY)
+		if(delete) //Wardens can modify security record entries, but cannot delete them; only HoS, Silicons and Captain can do that.
+			req_access = list(ACCESS_SECURITY, ACCESS_ARMORY, ACCESS_KEYCARD_AUTH)
+		if(!check_access(I))
+			req_access = null
+			return FALSE
+		req_access = null
+	return TRUE
+
+/obj/machinery/computer/secure_data/proc/delete_allrecords_feedback()
+	temp = ""
+	if(check_input_clearance(usr, TRUE))
+		temp += "<h5><b>Are you sure you wish to delete all Security records?</b></h5><br>"
+		temp += "<a href='?src=[REF(src)];choice=Purge All Records'>Yes</a><br>"
+		temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"
+	else
+		temp += "<a href='?src=[REF(src)];choice=Clear Screen'><b>[SEC_RECORD_BAD_CLEARANCE]</b></a>"
+	return temp
+
+
+/obj/machinery/computer/secure_data/proc/delete_record_feedback(type = "Security Portion Only")
+	temp = ""
+	if(check_input_clearance(usr, TRUE))
+		temp = "<h5><b>Are you sure you wish to delete the record ([type])?</b></h5><br>"
+		temp += "<a href='?src=[REF(src)];choice=Delete Record ([type]) Execute'>Yes</a><br>"
+		temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"
+	else
+		temp += "<a href='?src=[REF(src)];choice=Clear Screen'><b>[SEC_RECORD_BAD_CLEARANCE]</b></a>"
+
+	return temp

--- a/code/FulpstationCode/improved_record_security/fulp_improved_record_security.dm
+++ b/code/FulpstationCode/improved_record_security/fulp_improved_record_security.dm
@@ -1,5 +1,46 @@
 #define SEC_RECORD_BAD_CLEARANCE "ACCESS DENIED: User ID has inadequate clearance."
 
+#define SEC_RECORD_BOT_COOLDOWN 60 SECONDS
+
+
+/mob/living/simple_animal/bot/secbot/proc/arrest_security_record(mob/living/carbon/C, arrest_type, threat, location)
+
+	if(!C) //Sanity
+		return
+
+	if(arrest_cooldown.Find(C)) //Don't arrest people whose names are in the cooldown list
+		return
+
+	for(var/obj/machinery/computer/secure_data/sec_comp in GLOB.machines)
+		if(sec_comp)
+			sec_comp.secbot_entry(C, src, arrest_type, threat, location)
+			arrest_cooldown += C
+			addtimer(CALLBACK(src, /mob/living/simple_animal/bot/secbot.proc/sec_record_bot_cooldown_end,C), SEC_RECORD_BOT_COOLDOWN)
+			return
+
+/mob/living/simple_animal/bot/secbot/proc/sec_record_bot_cooldown_end(mob/living/carbon/C)
+	arrest_cooldown -= C //Remove from the cooldown list
+
+
+/obj/machinery/computer/secure_data/proc/secbot_entry(mob/living/carbon/C, mob/living/simple_animal/bot/secbot/S, arrest_type, threat, location)
+	var/bot_authenticated = "[S.name]"
+	var/bot_rank = "Security Robot"
+	var/t1 = "[bot_authenticated] [arrest_type ? "Detained" : "Arrested"] [C] at [location]. Threat level: [threat]"
+
+	for(var/datum/data/record/R in GLOB.data_core.security)
+		if(!R) //Sanity
+			return
+
+		if(R.fields["name"] == "[C.name]")
+			active2 = R //We found the record we want
+			break
+
+	var/counter = 1
+	while(active2.fields[text("com_[]", counter)])
+		counter++
+	active2.fields[text("com_[]", counter)] = text("<b>Made by [] ([]) on [] [], []</b><BR>[]", bot_authenticated, bot_rank, station_time_timestamp(), time2text(world.realtime, "MMM DD"), GLOB.year_integer+540, t1)
+
+
 /obj/machinery/computer/secure_data/proc/check_input_clearance(mob/M, delete = FALSE)
 	if(!issilicon(M) && !IsAdminGhost(M)) //Silicons and AdminGhosts ignore access checks.
 		var/obj/item/card/id/I = M.get_idcard(TRUE)

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -500,9 +500,10 @@ What a mess.*/
 //RECORD DELETE
 			if("Delete All Records")
 				temp = ""
-				temp += "Are you sure you wish to delete all Security records?<br>"
+				temp = delete_allrecords_feedback() //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+				/*temp += "Are you sure you wish to delete all Security records?<br>"
 				temp += "<a href='?src=[REF(src)];choice=Purge All Records'>Yes</a><br>"
-				temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"
+				temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>*/
 
 			if("Purge All Records")
 				investigate_log("[key_name(usr)] has purged all the security records.", INVESTIGATE_RECORDS)
@@ -525,15 +526,17 @@ What a mess.*/
 
 			if("Delete Record (ALL)")
 				if(active1)
-					temp = "<h5>Are you sure you wish to delete the record (ALL)?</h5>"
+					delete_record_feedback("ALL") //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+					/*temp = "<h5>Are you sure you wish to delete the record (ALL)?</h5>"
 					temp += "<a href='?src=[REF(src)];choice=Delete Record (ALL) Execute'>Yes</a><br>"
-					temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"
+					temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"*/
 
 			if("Delete Record (Security)")
 				if(active2)
-					temp = "<h5>Are you sure you wish to delete the record (Security Portion Only)?</h5>"
+					delete_record_feedback() //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+					/*temp = "<h5>Are you sure you wish to delete the record (Security Portion Only)?</h5>"
 					temp += "<a href='?src=[REF(src)];choice=Delete Record (Security) Execute'>Yes</a><br>"
-					temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"
+					temp += "<a href='?src=[REF(src)];choice=Clear Screen'>No</a>"*/
 
 			if("Delete Entry")
 				if((istype(active2, /datum/data/record) && active2.fields[text("com_[]", href_list["del_c"])]))
@@ -609,6 +612,10 @@ What a mess.*/
 				switch(href_list["field"])
 					if("name")
 						if(istype(active1, /datum/data/record) || istype(active2, /datum/data/record))
+							if(!check_input_clearance(usr)) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+								alert(usr, "[SEC_RECORD_BAD_CLEARANCE]")
+								return
+
 							var/t1 = copytext(sanitize(input("Please input name:", "Secure. records", active1.fields["name"], null)  as text),1,MAX_MESSAGE_LEN)
 							if(!canUseSecurityRecordsConsole(usr, t1, a1))
 								return
@@ -618,6 +625,10 @@ What a mess.*/
 								active2.fields["name"] = t1
 					if("id")
 						if(istype(active2, /datum/data/record) || istype(active1, /datum/data/record))
+							if(!check_input_clearance(usr)) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+								alert(usr, "[SEC_RECORD_BAD_CLEARANCE]")
+								return
+
 							var/t1 = stripped_input(usr, "Please input id:", "Secure. records", active1.fields["id"], null)
 							if(!canUseSecurityRecordsConsole(usr, t1, a1))
 								return
@@ -627,12 +638,20 @@ What a mess.*/
 								active2.fields["id"] = t1
 					if("fingerprint")
 						if(istype(active1, /datum/data/record))
+							if(!check_input_clearance(usr)) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+								alert(usr, "[SEC_RECORD_BAD_CLEARANCE]")
+								return
+
 							var/t1 = stripped_input(usr, "Please input fingerprint hash:", "Secure. records", active1.fields["fingerprint"], null)
 							if(!canUseSecurityRecordsConsole(usr, t1, a1))
 								return
 							active1.fields["fingerprint"] = t1
 					if("gender")
 						if(istype(active1, /datum/data/record))
+							if(!check_input_clearance(usr)) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+								alert(usr, "[SEC_RECORD_BAD_CLEARANCE]")
+								return
+
 							if(active1.fields["gender"] == "Male")
 								active1.fields["gender"] = "Female"
 							else if(active1.fields["gender"] == "Female")
@@ -641,8 +660,12 @@ What a mess.*/
 								active1.fields["gender"] = "Male"
 					if("age")
 						if(istype(active1, /datum/data/record))
+							if(!check_input_clearance(usr)) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+								alert(usr, "[SEC_RECORD_BAD_CLEARANCE]")
+								return
+
 							var/t1 = input("Please input age:", "Secure. records", active1.fields["age"], null) as num|null
-							
+
 							if (!t1)
 								return
 
@@ -651,6 +674,10 @@ What a mess.*/
 							active1.fields["age"] = t1
 					if("species")
 						if(istype(active1, /datum/data/record))
+							if(!check_input_clearance(usr)) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019
+								alert(usr, "[SEC_RECORD_BAD_CLEARANCE]")
+								return
+
 							var/t1 = input("Select a species", "Species Selection") as null|anything in GLOB.roundstart_races
 							if(!canUseSecurityRecordsConsole(usr, t1, a1))
 								return
@@ -733,7 +760,7 @@ What a mess.*/
 						if(istype(active1, /datum/data/record))
 							var/t1 = stripped_input(usr, "Please input citation crime:", "Secure. records", "", null)
 							var/fine = FLOOR(input(usr, "Please input citation fine:", "Secure. records", 50) as num|null, 1)
-							
+
 							if (isnull(fine))
 								return
 
@@ -745,7 +772,7 @@ What a mess.*/
 
 							if(!canUseSecurityRecordsConsole(usr, t1, null, a2))
 								return
-								
+
 							var/crime = GLOB.data_core.createCrimeEntry(t1, "", authenticated, station_time_timestamp(), fine)
 							for (var/obj/item/pda/P in GLOB.PDAs)
 								if(P.owner == active1.fields["name"])

--- a/code/modules/mob/living/simple_animal/bot/secbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/secbot.dm
@@ -291,6 +291,9 @@ Auto Patrol: []"},
 	if(declare_arrests)
 		var/area/location = get_area(src)
 		speak("[arrest_type ? "Detaining" : "Arresting"] level [threat] scumbag <b>[C]</b> in [location].", radio_channel)
+
+		arrest_security_record(C, arrest_type, threat, location) //FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019; this makes a record of the arrest, including timestamp and location.
+
 	C.visible_message("<span class='danger'>[src] has stunned [C]!</span>",\
 							"<span class='userdanger'>[src] has stunned you!</span>")
 

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -37,3 +37,20 @@
 
 /obj/item/clothing/suit/space/hardsuit
 	var/toggle_helmet_sound = 'sound/mecha/mechmove03.ogg'
+
+//*************************************************************************
+//** FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019 BEGINS
+//**-----------------------------------------------------------------------
+//** -Adds security levels to the security record computer.
+//** -Adds arrest logging for security bots.
+//*************************************************************************
+
+/mob/living/simple_animal/bot/secbot
+	var/list/arrest_cooldown = list() //If you're in the list, we don't log the arrest
+
+//*************************************************************************
+//** FULPSTATION IMPROVED RECORD SECURITY PR -Surrealistik Oct 2019 ENDS
+//**-----------------------------------------------------------------------
+//** -Adds security levels to the security record computer.
+//** -Adds arrest logging for security bots.
+//*************************************************************************


### PR DESCRIPTION
## About The Pull Request

Per title. Permission levels have been added to the Security console.

All security personnel can add/remove/edit offenses and subject status (arrest, incarcerated, etc).

Warden can do the above and edit key security record parameters such as names, fingerprints, race, etc...

Silicons, HoS and the Captain can delete security records in addition to all of the above.

Secbots now also log arrests and relevant details like time and location.

## Why It's Good For The Game

Stops rando Security Officers/Deputies from crippling Sec by deleting security records wholesale, and makes it significantly harder to cripple security in this way.

## Changelog
:cl:
add: 3 level permissions system added to Security Records. L1 access (Security) can edit offenses and arrest status. L2 access (Warden) can do what L1 can and change key record parameters (name, race, etc). L3 access (HoS, Silicons, Captain) can do what L1 and 2 can and can delete records.
add: Secbots now log arrests and relevant details like time and location.
/:cl: