### PR TITLE
Cryotubes Now Have a Lockdown Mode

### DIFF
--- a/code/FulpstationCode/fulp_cryo/fulp_cryo.dm
+++ b/code/FulpstationCode/fulp_cryo/fulp_cryo.dm
@@ -117,6 +117,7 @@
 	return FALSE
 
 
-/obj/machinery/atmospherics/components/unary/cryo_cell/emag_act(mob/user)
-	lockdown = FALSE
-	to_chat(user, "<span class='danger'>You disable [src]'s lockdown mode.</span>")
+/obj/machinery/atmospherics/components/unary/cryo_cell/emag_act(mob/user) //Emag turns off the lockdown mode
+	if(lockdown)
+		lockdown = FALSE
+		to_chat(user, "<span class='danger'>You disable [src]'s lockdown mode.</span>")

--- a/code/FulpstationCode/fulp_cryo/fulp_cryo.dm
+++ b/code/FulpstationCode/fulp_cryo/fulp_cryo.dm
@@ -1,0 +1,122 @@
+/obj/machinery/atmospherics/components/unary/cryo_cell/proc/fulp_ui_data()
+	var/list/data = list()
+	data["isOperating"] = on
+	data["hasOccupant"] = occupant ? TRUE : FALSE
+	data["isOpen"] = state_open
+	data["autoEject"] = autoeject
+	data["lockDown"] = lockdown
+
+	data["occupant"] = list()
+	if(occupant)
+		var/mob/living/mob_occupant = occupant
+		data["occupant"]["name"] = mob_occupant.name
+		switch(mob_occupant.stat)
+			if(CONSCIOUS)
+				data["occupant"]["stat"] = "Conscious"
+				data["occupant"]["statstate"] = "good"
+			if(SOFT_CRIT)
+				data["occupant"]["stat"] = "Conscious"
+				data["occupant"]["statstate"] = "average"
+			if(UNCONSCIOUS)
+				data["occupant"]["stat"] = "Unconscious"
+				data["occupant"]["statstate"] = "average"
+			if(DEAD)
+				data["occupant"]["stat"] = "Dead"
+				data["occupant"]["statstate"] = "bad"
+		data["occupant"]["health"] = round(mob_occupant.health, 1)
+		data["occupant"]["maxHealth"] = mob_occupant.maxHealth
+		data["occupant"]["minHealth"] = HEALTH_THRESHOLD_DEAD
+		data["occupant"]["bruteLoss"] = round(mob_occupant.getBruteLoss_nonProsthetic(), 1) // FULP: Don't count Prosthetics.
+		data["occupant"]["oxyLoss"] = round(mob_occupant.getOxyLoss(), 1)
+		data["occupant"]["toxLoss"] = round(mob_occupant.getToxLoss(), 1)
+		data["occupant"]["fireLoss"] = round(mob_occupant.getFireLoss_nonProsthetic(), 1) // FULP: Don't count Prosthetics.
+		data["occupant"]["bodyTemperature"] = round(mob_occupant.bodytemperature, 1)
+		if(mob_occupant.bodytemperature < TCRYO)
+			data["occupant"]["temperaturestatus"] = "good"
+		else if(mob_occupant.bodytemperature < T0C)
+			data["occupant"]["temperaturestatus"] = "average"
+		else
+			data["occupant"]["temperaturestatus"] = "bad"
+
+	var/datum/gas_mixture/air1 = airs[1]
+	data["cellTemperature"] = round(air1.temperature, 1)
+
+	data["isBeakerLoaded"] = beaker ? TRUE : FALSE
+	var/beakerContents = list()
+	if(beaker && beaker.reagents && beaker.reagents.reagent_list.len)
+		for(var/datum/reagent/R in beaker.reagents.reagent_list)
+			beakerContents += list(list("name" = R.name, "volume" = R.volume))
+	data["beakerContents"] = beakerContents
+	return data
+
+/obj/machinery/atmospherics/components/unary/cryo_cell/proc/fulp_ui_act(action, params)
+
+	var/mob/M = usr
+	var/obj/item/card/id/I = M.get_idcard(TRUE)
+	if(lockdown && (!I || !check_access(I)) ) //If we're in lockdown mode we check for medical access
+		to_chat(M, "<span class='danger'>[src] in lockdown mode; medical authorization required. Access denied.</span>")
+		playsound(src, 'sound/machines/buzz-two.ogg', volume)
+		return FALSE
+
+	playsound(src, 'sound/machines/beep.ogg', volume)
+	switch(action)
+		if("power")
+			if(on)
+				on = FALSE
+			else if(!state_open)
+				on = TRUE
+			update_icon()
+			return TRUE
+		if("door")
+			if(state_open)
+				close_machine()
+			else
+				open_machine()
+			return TRUE
+		if("autoeject")
+			autoeject = !autoeject
+			return TRUE
+		if("ejectbeaker")
+			if(beaker)
+				beaker.forceMove(drop_location())
+				if(Adjacent(usr) && !issilicon(usr))
+					usr.put_in_hands(beaker)
+				beaker = null
+				return TRUE
+		if("lockdown")
+			if(!I || !check_access(I))
+				to_chat(M, "<span class='danger'>Medical authorization required to toggle lockdown mode. Access denied.</span>")
+				playsound(src, 'sound/machines/buzz-two.ogg', volume)
+				return FALSE
+			lockdown = !lockdown
+			return TRUE
+
+	return FALSE
+
+/obj/machinery/atmospherics/components/unary/cryo_cell/proc/check_id(obj/item/I, mob/user, params)
+	var/obj/item/card/id/C
+	if (istype(I, /obj/item/card/id))
+		C = I
+	else if (istype(I, /obj/item/pda))
+		var/obj/item/pda/P = I
+		C = P.id
+
+	if(!C)
+		return FALSE
+
+	if(check_access(C))
+		lockdown = !lockdown
+		playsound(src, 'sound/machines/beep.ogg', volume)
+		to_chat(user, "<span class='notice'>You toggle [src]'s lockdown mode [lockdown ? "on" : "off"]</span>")
+		return TRUE
+
+	else
+		playsound(src, 'sound/machines/buzz-two.ogg', volume)
+		to_chat(user, "<span class='notice'>You lack sufficient access to toggle [src]'s lockdown mode.</span>")
+
+	return FALSE
+
+
+/obj/machinery/atmospherics/components/unary/cryo_cell/emag_act(mob/user)
+	lockdown = FALSE
+	to_chat(user, "<span class='danger'>You disable [src]'s lockdown mode.</span>")

--- a/code/FulpstationCode/fulp_cryo/fulp_cryo.dm
+++ b/code/FulpstationCode/fulp_cryo/fulp_cryo.dm
@@ -1,3 +1,5 @@
+#define FULP_CRYO_INTERFACE_VOLUME 30
+
 /obj/machinery/atmospherics/components/unary/cryo_cell/proc/fulp_ui_data()
 	var/list/data = list()
 	data["isOperating"] = on
@@ -55,10 +57,10 @@
 	var/obj/item/card/id/I = M.get_idcard(TRUE)
 	if(lockdown && (!I || !check_access(I)) ) //If we're in lockdown mode we check for medical access
 		to_chat(M, "<span class='danger'>[src] in lockdown mode; medical authorization required. Access denied.</span>")
-		playsound(src, 'sound/machines/buzz-two.ogg', volume)
+		playsound(src, 'sound/machines/buzz-two.ogg', FULP_CRYO_INTERFACE_VOLUME)
 		return FALSE
 
-	playsound(src, 'sound/machines/beep.ogg', volume)
+	playsound(src, 'sound/machines/beep.ogg', FULP_CRYO_INTERFACE_VOLUME)
 	switch(action)
 		if("power")
 			if(on)
@@ -86,7 +88,7 @@
 		if("lockdown")
 			if(!I || !check_access(I))
 				to_chat(M, "<span class='danger'>Medical authorization required to toggle lockdown mode. Access denied.</span>")
-				playsound(src, 'sound/machines/buzz-two.ogg', volume)
+				playsound(src, 'sound/machines/buzz-two.ogg', FULP_CRYO_INTERFACE_VOLUME)
 				return FALSE
 			lockdown = !lockdown
 			return TRUE
@@ -102,22 +104,27 @@
 		C = P.id
 
 	if(!C)
-		return FALSE
+		return
+
+	req_one_access = list(ACCESS_MEDICAL)
 
 	if(check_access(C))
 		lockdown = !lockdown
-		playsound(src, 'sound/machines/beep.ogg', volume)
+		playsound(src, 'sound/machines/beep.ogg', 30)
 		to_chat(user, "<span class='notice'>You toggle [src]'s lockdown mode [lockdown ? "on" : "off"]</span>")
-		return TRUE
 
 	else
-		playsound(src, 'sound/machines/buzz-two.ogg', volume)
-		to_chat(user, "<span class='notice'>You lack sufficient access to toggle [src]'s lockdown mode.</span>")
+		playsound(src, 'sound/machines/buzz-two.ogg', 30)
+		to_chat(user, "<span class='warning'>You lack sufficient access to toggle [src]'s lockdown mode.</span>")
 
-	return FALSE
+	if(!lockdown)
+		req_one_access = null
+
+	return
 
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/emag_act(mob/user) //Emag turns off the lockdown mode
 	if(lockdown)
 		lockdown = FALSE
+		req_one_access = null
 		to_chat(user, "<span class='danger'>You disable [src]'s lockdown mode.</span>")

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -306,6 +306,9 @@
 			close_machine(target)
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/attackby(obj/item/I, mob/user, params)
+	if(check_id(I, user, params)) //FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019
+		return
+
 	if(istype(I, /obj/item/reagent_containers/glass))
 		. = 1 //no afterattack
 		if(beaker)
@@ -335,11 +338,12 @@
 																	datum/tgui/master_ui = null, datum/ui_state/state = GLOB.notcontained_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "cryo", name, ui_x, ui_y, master_ui, state)
+		ui = new(user, src, ui_key, "FulpCryo", name, ui_x, ui_y, master_ui, state) //FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019
 		ui.open()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_data()
-	var/list/data = list()
+	var/list/data = fulp_ui_data()
+	/*var/list/data = list()
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? TRUE : FALSE
 	data["isOpen"] = state_open
@@ -385,13 +389,15 @@
 	if(beaker && beaker.reagents && beaker.reagents.reagent_list.len)
 		for(var/datum/reagent/R in beaker.reagents.reagent_list)
 			beakerContents += list(list("name" = R.name, "volume" = R.volume))
-	data["beakerContents"] = beakerContents
+	data["beakerContents"] = beakerContents*/
 	return data
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_act(action, params)
 	if(..())
 		return
-	switch(action)
+
+	. = fulp_ui_act(action, params)
+	/*switch(action)
 		if("power")
 			if(on)
 				on = FALSE
@@ -414,7 +420,7 @@
 				if(Adjacent(usr) && !issilicon(usr))
 					usr.put_in_hands(beaker)
 				beaker = null
-				. = TRUE
+				. = TRUE*/
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/CtrlClick(mob/user)
 	if(user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK) && !state_open)

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -338,7 +338,7 @@
 																	datum/tgui/master_ui = null, datum/ui_state/state = GLOB.notcontained_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
-		ui = new(user, src, ui_key, "FulpCryo", name, ui_x, ui_y, master_ui, state) //FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019
+		ui = new(user, src, ui_key, "cryo", name, ui_x, ui_y, master_ui, state) //FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019
 		ui.open()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_data()

--- a/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/cryo.dm
@@ -342,7 +342,8 @@
 		ui.open()
 
 /obj/machinery/atmospherics/components/unary/cryo_cell/ui_data()
-	var/list/data = fulp_ui_data()
+	var/list/data = list() //FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019
+	data = fulp_ui_data()
 	/*var/list/data = list()
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? TRUE : FALSE
@@ -396,7 +397,7 @@
 	if(..())
 		return
 
-	. = fulp_ui_act(action, params)
+	. = fulp_ui_act(action, params) //FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019
 	/*switch(action)
 		if("power")
 			if(on)

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -47,8 +47,7 @@
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	var/lockdown = FALSE //Does operating the cryo cell require medical access?
-	req_one_access = list(ACCESS_MEDICAL)
-
+	req_one_access = null
 
 //******************************************************************************
 //** FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019 - ENDS

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -37,3 +37,14 @@
 
 /obj/item/clothing/suit/space/hardsuit
 	var/toggle_helmet_sound = 'sound/mecha/mechmove03.ogg'
+
+//*************************************************************************
+//**
+//**
+//**
+//*************************************************************************
+
+
+/obj/machinery/atmospherics/components/unary/cryo_cell
+	var/lockdown = FALSE //Does operating the cryo cell require medical access?
+	req_one_access = list(ACCESS_MEDICAL)

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -38,13 +38,20 @@
 /obj/item/clothing/suit/space/hardsuit
 	var/toggle_helmet_sound = 'sound/mecha/mechmove03.ogg'
 
-//*************************************************************************
+//******************************************************************************
+//** FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019 - BEGINS
+//**----------------------------------------------------------------------------
 //**
-//**
-//**
-//*************************************************************************
+//******************************************************************************
 
 
 /obj/machinery/atmospherics/components/unary/cryo_cell
 	var/lockdown = FALSE //Does operating the cryo cell require medical access?
 	req_one_access = list(ACCESS_MEDICAL)
+
+
+//******************************************************************************
+//** FULPSTATION Lockdown Mode for Cryocell PR by Surrealistik Nov 2019 - ENDS
+//**----------------------------------------------------------------------------
+//**
+//******************************************************************************

--- a/tgui-next/packages/tgui/interfaces/FulpCryo.js
+++ b/tgui-next/packages/tgui/interfaces/FulpCryo.js
@@ -1,0 +1,145 @@
+import { Fragment } from 'inferno';
+import { act } from '../byond';
+import { AnimatedNumber, Box, Button, LabeledList, ProgressBar, Section} from '../components';
+
+export const Cryo = props => {
+  const { state } = props;
+  const { config, data } = state;
+  const { ref } = config;
+  const damageTypes = [
+    {
+      label: "Brute",
+      type: "bruteLoss",
+    },
+    {
+      label: "Respiratory",
+      type: "oxyLoss",
+    },
+    {
+      label: "Toxin",
+      type: "toxLoss",
+    },
+    {
+      label: "Burn",
+      type: "fireLoss",
+    },
+  ];
+
+  return (
+    <Fragment>
+      <Section title="Occupant">
+        <LabeledList>
+          <LabeledList.Item
+            label="Occupant"
+            content={data.occupant.name ? data.occupant.name : "No Occupant"} />
+          {!!data.hasOccupant && (
+            <Fragment>
+              <LabeledList.Item
+                label="State"
+                content={data.occupant.stat}
+                color={data.occupant.statstate} />
+              <LabeledList.Item
+                label="Temperature"
+                color={data.occupant.temperaturestatus}>
+                <AnimatedNumber value={data.occupant.bodyTemperature} /> K
+              </LabeledList.Item>
+              <LabeledList.Item label="Health">
+                <ProgressBar
+                  value={data.occupant.health / data.occupant.maxHealth}
+                  color={(data.occupant.health > 0) ? "good" : "average"}>
+                  <AnimatedNumber value={data.occupant.health} />
+                </ProgressBar>
+              </LabeledList.Item>
+              {(damageTypes.map(damageType => (
+                <LabeledList.Item
+                  key={damageType.id}
+                  label={damageType.label}>
+                  <ProgressBar
+                    value={data.occupant[damageType.type]/100}>
+                    <AnimatedNumber value={data.occupant[damageType.type]} />
+                  </ProgressBar>
+                </LabeledList.Item>
+              )))}
+            </Fragment>
+          )}
+        </LabeledList>
+      </Section>
+      <Section title="Cell">
+        <LabeledList>
+          <LabeledList.Item
+            label="Power"
+            content={(
+              <Button
+                icon={data.isOperating ? "power-off" : "times"}
+                disabled={data.isOpen}
+                onClick={() => act(ref, 'power')}
+                color={data.isOperating && ("green")}>
+                {data.isOperating ? "On" : "Off"}
+              </Button>
+            )} />
+          <LabeledList.Item label="Temperature">
+            <AnimatedNumber value={data.cellTemperature} /> K
+          </LabeledList.Item>
+          <LabeledList.Item label="Door">
+            <Button
+              icon={data.isOpen ? "unlock" : "lock"}
+              onClick={() => act(ref, 'door')}
+              content={data.isOpen ? "Open" : "Closed"} />
+            <Button
+              icon={data.autoEject ? "sign-out-alt" : "sign-in-alt"}
+              onClick={() => act(ref, 'autoeject')}
+              content={data.autoEject ? "Auto" : "Manual"} />
+            <Button
+              icon={data.lockDown ? "sign-out-alt" : "sign-in-alt"}
+              onClick={() => act(ref, 'lockdown')}
+              content={data.autoEject ? "On" : "Off"} />
+            <Button
+              icon={data.autoEject ? "sign-out-alt" : "sign-in-alt"}
+              onClick={() => act(ref, 'autoeject')}
+              content={data.autoEject ? "Auto" : "Manual"} />
+          </LabeledList.Item>
+		  <LabeledList.Item label="Notifications">
+            <Button
+              icon={data.announceMents ? "sign-out-alt" : "sign-in-alt"}
+              onClick={() => act(ref, 'announcements')}
+              content={data.announceMents ? "On" : "Off"} />
+		  </LabeledList.Item>
+		  <LabeledList.Item label="Lock Access">
+            <Button
+              icon={data.lockDown ? "sign-out-alt" : "sign-in-alt"}
+              onClick={() => act(ref, 'lockdown')}
+              content={data.lockDown ? "On" : "Off"} />
+		  </LabeledList.Item>
+        </LabeledList>
+      </Section>
+      <Section
+        title="Beaker"
+        buttons={(
+          <Button
+            icon="eject"
+            disabled={!data.isBeakerLoaded}
+            onClick={() => act(ref, 'ejectbeaker')}
+            content="Eject" />
+        )}>
+        <LabeledList>
+          <LabeledList.Item label="Contents">
+            {data.isBeakerLoaded ? (
+              data.beakerContents.length ? (
+                data.beakerContents.map(beakerContent => (
+                  <Box
+                    key={beakerContent.id}
+                    color="pale-blue" >
+                    {beakerContent.volume} units of {beakerContent.name}
+                  </Box>
+                ))
+              ) : (
+                <Box color="bad" content="Beaker Empty" />
+              )
+            ) : (
+              <Box color="average" content="No Beaker" />
+            )}
+          </LabeledList.Item>
+        </LabeledList>
+      </Section>
+    </Fragment>
+  ); };


### PR DESCRIPTION
## About The Pull Request

Allows people to lockdown cryotubes, and making them require an ID with medbay access to operate.

An emag will be able to disable the lockdown mode.

## Why It's Good For The Game

Makes griefing cryotubes significantly more difficult.

## Changelog
:cl:
add: IDs with medical access can now have cryotubes enter lockdown mode by swiping them. A cryotube in lockdown mode requires medical access to operate. Emags cancel this lockdown mode.
/:cl: