### PR TITLE
Proper Radio Channels for Borgs

### DIFF
--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -53,7 +53,17 @@
 	keyslot = new /obj/item/encryptionkey/headset_med
 
 
+/mob/living/silicon/robot/modules/engineering
+	radio = /obj/item/radio/borg/medical
+
+/obj/item/radio/borg/engineering
+	keyslot = new /obj/item/encryptionkey/headset_eng
+
+
 /mob/living/silicon/robot/modules/security
+	radio = /obj/item/radio/borg/security
+
+/mob/living/silicon/robot/modules/peacekeeper
 	radio = /obj/item/radio/borg/security
 
 /obj/item/radio/borg/security
@@ -74,9 +84,6 @@
 	radio = /obj/item/radio/borg/service
 
 /mob/living/silicon/robot/modules/janitor
-	radio = /obj/item/radio/borg/service
-
-/mob/living/silicon/robot/modules/peacekeeper
 	radio = /obj/item/radio/borg/service
 
 /mob/living/silicon/robot/modules/butler

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -37,3 +37,56 @@
 
 /obj/item/clothing/suit/space/hardsuit
 	var/toggle_helmet_sound = 'sound/mecha/mechmove03.ogg'
+
+
+//***********************************************************************
+//** FULP PROPER RADIO CHANNELS FOR BORGS by Surrealistik Nov 2019 BEGINS
+//**---------------------------------------------------------------------
+//** Borgs now have access to appropriate secure radio channels
+//***********************************************************************
+
+
+/mob/living/silicon/robot/modules/medical
+	radio = /obj/item/radio/borg/medical
+
+/obj/item/radio/borg/medical
+	keyslot = new /obj/item/encryptionkey/headset_med
+
+
+/mob/living/silicon/robot/modules/security
+	radio = /obj/item/radio/borg/security
+
+/obj/item/radio/borg/security
+	keyslot = new /obj/item/encryptionkey/headset_sec
+
+
+/mob/living/silicon/robot/modules/miner
+	radio = /obj/item/radio/borg/mining
+
+/obj/item/radio/borg/mining
+	keyslot = new /obj/item/encryptionkey/headset_mining
+
+
+/mob/living/silicon/robot/modules/clown
+	radio = /obj/item/radio/borg/service
+
+/mob/living/silicon/robot/modules/standard
+	radio = /obj/item/radio/borg/service
+
+/mob/living/silicon/robot/modules/janitor
+	radio = /obj/item/radio/borg/service
+
+/mob/living/silicon/robot/modules/peacekeeper
+	radio = /obj/item/radio/borg/service
+
+/mob/living/silicon/robot/modules/butler
+	radio = /obj/item/radio/borg/service
+
+/obj/item/radio/borg/service
+	keyslot = new /obj/item/encryptionkey/headset_service
+
+//***********************************************************************
+//** FULP PROPER RADIO CHANNELS FOR BORGS by Surrealistik Nov 2019 ENDS
+//**---------------------------------------------------------------------
+//** Borgs now have access to appropriate secure radio channels
+//***********************************************************************


### PR DESCRIPTION
## About The Pull Request

Borgs now gain access to role appropriate radio channels:

Medborgs get access to Medical.
Peacekeepers and Secborgs get access to Security.
Engiborgs get access to Engineering.
Mining borgs get access to Mining.

All other borgs get access to Service.

## Why It's Good For The Game

Helps borgs do their job by allowing them to be in better communication with their department and take appropriate cues.

## Changelog
:cl:
add: Borgs now gain access to role appropriate radio channels.
/:cl:
