### PR TITLE
Adds Body Cams to Sec Uniforms

### DIFF
--- a/code/FulpstationCode/body_camera_files/body_camera_procs.dm
+++ b/code/FulpstationCode/body_camera_files/body_camera_procs.dm
@@ -68,16 +68,15 @@
 /obj/item/clothing/under/rank/security/proc/camera_toggle()
 	var/message = "<span class='notice'>There's no camera!</span>"
 
-	if(!builtInCamera)
-
-	else if(camera_on)
-		camera_on = FALSE
-		builtInCamera.status = 0
-		message = "<span class='notice'>You toggle the body camera off.</span>"
-	else
-		camera_on = TRUE
-		builtInCamera.status = 1
-		message = "<span class='notice'>You toggle the body camera on.</span>"
+	if(builtInCamera)
+		if(camera_on)
+			camera_on = FALSE
+			builtInCamera.status = 0
+			message = "<span class='notice'>You toggle the body camera off.</span>"
+		else
+			camera_on = TRUE
+			builtInCamera.status = 1
+			message = "<span class='notice'>You toggle the body camera on.</span>"
 
 	if(ismob(loc))
 		var/mob/user = loc

--- a/code/FulpstationCode/body_camera_files/body_camera_procs.dm
+++ b/code/FulpstationCode/body_camera_files/body_camera_procs.dm
@@ -1,5 +1,7 @@
 #define SEC_BODY_CAM_SOUND list('sound/machines/beep.ogg')
+#define SEC_BODY_CAM_SOUND_DENY list('sound/machines/buzz-two.ogg')
 #define SEC_BODY_CAM_REG_DELAY 1 SECONDS
+#define SEC_BODY_CAM_COOLDOWN 2 SECONDS
 
 /obj/item/clothing/under/rank/security/Initialize()
 	. = ..()
@@ -47,7 +49,7 @@
 		register_body_camera(I, user)
 	else
 		to_chat(user, "<span class='warning'>ID is not authorized for registration with this uniform's body camera.</span>")
-
+		camera_sound(FALSE)
 
 /obj/item/clothing/under/rank/security/proc/register_body_camera(obj/item/card/id/I, mob/user)
 	if(!I) //Sanity check
@@ -116,9 +118,12 @@
 			camera_sound()
 			to_chat(user, "[message]")
 
-/obj/item/clothing/under/rank/security/proc/camera_sound()
-	if(world.time - sound_time_stamp > 20)
-		playsound(loc, SEC_BODY_CAM_SOUND, get_clamped_volume(), TRUE, -1)
+/obj/item/clothing/under/rank/security/proc/camera_sound(accepted = TRUE)
+	if(world.time - sound_time_stamp > SEC_BODY_CAM_COOLDOWN)
+		if(accepted)
+			playsound(loc, SEC_BODY_CAM_SOUND, get_clamped_volume(), TRUE, -1)
+		else
+			playsound(loc, SEC_BODY_CAM_SOUND_DENY, get_clamped_volume(), TRUE, -1)
 		sound_time_stamp = world.time
 
 /obj/item/clothing/under/rank/security/emp_act()

--- a/code/FulpstationCode/body_camera_files/body_camera_procs.dm
+++ b/code/FulpstationCode/body_camera_files/body_camera_procs.dm
@@ -47,7 +47,7 @@
 
 	if(check_access(I))
 		var/id_name = I.registered_name
-		builtInCamera.c_tag = "*Body Camera: [I.assignment] [id_name]"
+		builtInCamera.c_tag = "-Body Camera: [id_name] ([I.assignment])"
 		camera_sound()
 		to_chat(user, "<span class='notice'>Security uniform body camera manually registered with ID to [id_name]</span>")
 	else

--- a/code/FulpstationCode/body_camera_files/body_camera_procs.dm
+++ b/code/FulpstationCode/body_camera_files/body_camera_procs.dm
@@ -1,0 +1,101 @@
+#define SEC_BODY_CAM_SOUND list('sound/machines/beep.ogg')
+
+/obj/item/clothing/under/rank/security/Initialize()
+	. = ..()
+	builtInCamera = new (src)
+	builtInCamera.network = list("sec_bodycameras")
+	builtInCamera.internal_light = FALSE
+
+	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, .proc/auto_register_bodycam)
+
+
+/obj/item/clothing/under/rank/security/proc/auto_register_bodycam(datum/source, mob/user, slot)
+	if(!builtInCamera)
+		return
+	if(slot != SLOT_W_UNIFORM)
+		return
+	if(!user)
+		if(ismob(loc))
+			user = loc
+		else
+			return
+	var/obj/item/card/id/I = user.get_idcard(TRUE)
+	if(!istype(I))
+		return
+	if(check_access(I))
+		var/id_name = I.registered_name
+		builtInCamera.c_tag = "*Body Camera: [I.assignment] [id_name]"
+		camera_sound()
+		to_chat(user, "<span class='notice'>Security uniform body camera automatically registered to [id_name]</span>")
+
+/obj/item/clothing/under/rank/security/attackby(obj/item/W, mob/user, params)
+	. = ..()
+	if(!builtInCamera)
+		to_chat(user, "<span class='warning'>No body camera detected.</span>")
+		return
+
+	var/obj/item/card/id/I
+	if (istype(W, /obj/item/card/id))
+		I = W
+	else if (istype(W, /obj/item/pda))
+		var/obj/item/pda/P = W
+		I = P.id
+
+	if(!I)
+		to_chat(user, "<span class='warning'>No ID detected for body camera registration.</span>")
+		return
+
+	if(check_access(I))
+		var/id_name = I.registered_name
+		builtInCamera.c_tag = "*Body Camera: [I.assignment] [id_name]"
+		camera_sound()
+		to_chat(user, "<span class='notice'>Security uniform body camera manually registered with ID to [id_name]</span>")
+	else
+		to_chat(user, "<span class='warning'>ID is not authorized for registration with this uniform's body camera.</span>")
+
+/obj/item/clothing/under/rank/security/verb/toggle_camera()
+	set name = "Toggle Body Camera"
+	set category = "Object"
+	set src in usr
+	var/mob/M = usr
+	if (istype(M, /mob/dead/))
+		return
+	if (!can_use(M))
+		return
+	camera_toggle(usr)
+
+
+/obj/item/clothing/under/rank/security/proc/camera_toggle()
+	var/message = "<span class='notice'>There's no camera!</span>"
+
+	if(!builtInCamera)
+
+	else if(camera_on)
+		camera_on = FALSE
+		builtInCamera.status = 0
+		message = "<span class='notice'>You toggle the body camera off.</span>"
+	else
+		camera_on = TRUE
+		builtInCamera.status = 1
+		message = "<span class='notice'>You toggle the body camera on.</span>"
+
+	if(ismob(loc))
+		var/mob/user = loc
+		if(user)
+			camera_sound()
+			to_chat(user, "[message]")
+
+/obj/item/clothing/under/rank/security/proc/camera_sound()
+	if(world.time - sound_time_stamp > 20)
+		playsound(loc, SEC_BODY_CAM_SOUND, get_clamped_volume(), TRUE, -1)
+		sound_time_stamp = world.time
+
+/obj/item/clothing/under/rank/security/emp_act()
+	. = ..()
+	camera_toggle()
+
+/obj/machinery/computer/security/proc/check_bodycamera_unlock(user)
+	if(allowed(user))
+		network += "sec_bodycameras" //We can tap into the body camera network with appropriate access
+	else
+		network -= "sec_bodycameras"

--- a/code/FulpstationCode/body_camera_files/body_camera_procs.dm
+++ b/code/FulpstationCode/body_camera_files/body_camera_procs.dm
@@ -10,12 +10,12 @@
 
 	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, .proc/auto_register_bodycam)
 
-	addtimer(CALLBACK(src, /obj/item/clothing/under/rank/security.proc/auto_register_bodycam, null, SLOT_W_UNIFORM), SEC_BODY_CAM_REG_DELAY)
+	addtimer(CALLBACK(src, /obj/item/clothing/under/rank/security.proc/auto_register_bodycam, null, ITEM_SLOT_ICLOTHING), SEC_BODY_CAM_REG_DELAY)
 
 /obj/item/clothing/under/rank/security/proc/auto_register_bodycam(mob/user, slot)
 	if(!builtInCamera)
 		return
-	if(slot != SLOT_W_UNIFORM)
+	if(slot != ITEM_SLOT_ICLOTHING)
 		return
 	if(!user)
 		if(ismob(loc))

--- a/code/FulpstationCode/body_camera_files/body_camera_procs.dm
+++ b/code/FulpstationCode/body_camera_files/body_camera_procs.dm
@@ -1,4 +1,5 @@
 #define SEC_BODY_CAM_SOUND list('sound/machines/beep.ogg')
+#define SEC_BODY_CAM_REG_DELAY 0.5 SECONDS
 
 /obj/item/clothing/under/rank/security/Initialize()
 	. = ..()
@@ -8,8 +9,9 @@
 
 	RegisterSignal(src, COMSIG_ITEM_EQUIPPED, .proc/auto_register_bodycam)
 
+	addtimer(CALLBACK(src, /obj/item/clothing/under/rank/security.proc/auto_register_bodycam, null, SLOT_W_UNIFORM), SEC_BODY_CAM_REG_DELAY)
 
-/obj/item/clothing/under/rank/security/proc/auto_register_bodycam(datum/source, mob/user, slot)
+/obj/item/clothing/under/rank/security/proc/auto_register_bodycam(mob/user, slot)
 	if(!builtInCamera)
 		return
 	if(slot != SLOT_W_UNIFORM)
@@ -24,7 +26,7 @@
 		return
 	if(check_access(I))
 		var/id_name = I.registered_name
-		builtInCamera.c_tag = "*Body Camera: [I.assignment] [id_name]"
+		builtInCamera.c_tag = "-Body Camera: [id_name] ([I.assignment])"
 		camera_sound()
 		to_chat(user, "<span class='notice'>Security uniform body camera automatically registered to [id_name]</span>")
 

--- a/code/game/machinery/computer/camera.dm
+++ b/code/game/machinery/computer/camera.dm
@@ -70,6 +70,7 @@
 		user.unset_machine()
 		return
 
+	check_bodycamera_unlock(user) ///Fulpstation Sec Bodycamera PR - Surrealistik Oct 2019; allows access to the body camera network with Sec access.
 	var/list/camera_list = get_available_cameras()
 	if(!(user in watchers))
 		for(var/Num in camera_list)
@@ -85,6 +86,7 @@
 	use_camera_console(user)
 
 /obj/machinery/computer/security/proc/use_camera_console(mob/user)
+	check_bodycamera_unlock(user) ///Fulpstation Sec Bodycamera PR - Surrealistik Oct 2019; allows access to the body camera network with Sec access.
 	var/list/camera_list = get_available_cameras()
 	var/t = input(user, "Which camera should you change to?") as null|anything in camera_list
 	if(user.machine != src) //while we were choosing we got disconnected from our computer or are using another machine.

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -23,43 +23,6 @@
 	alt_covers_chest = TRUE
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
-	var/obj/machinery/camera/builtInCamera = null
-	var/camera_on = TRUE
-
-/obj/item/clothing/under/rank/security/officer/Initialize()
-	. = ..()
-	if(!builtInCamera)
-		builtInCamera = new (src)
-		builtInCamera.network = list("ss13")
-		builtInCamera.internal_light = FALSE
-
-
-/obj/item/clothing/under/rank/security/officer/equipped(mob/user, slot)
-	. = ..()
-	if(builtInCamera)
-		var/obj/item/card/id/I = user.get_idcard(TRUE)
-		if(istype(I))
-			builtInCamera.c_tag = I.registered_name
-
-/obj/item/clothing/under/rank/security/officer/verb/toggle_camera()
-	set name = "Toggle Body Camera"
-	set category = "Object"
-	set src in usr
-	var/mob/M = usr
-	if (istype(M, /mob/dead/))
-		return
-	if (!can_use(M))
-		return
-	if(!builtInCamera)
-		to_chat(usr, "There is no camera!")
-		return 0
-
-	if(camera_on)
-		camera_on = FALSE
-		builtInCamera.status = 0
-	else
-		camera_on = TRUE
-		builtInCamera.status = 1
 
 /obj/item/clothing/under/rank/security/officer/grey
 	name = "grey security jumpsuit"

--- a/code/modules/clothing/under/jobs/security.dm
+++ b/code/modules/clothing/under/jobs/security.dm
@@ -23,6 +23,43 @@
 	alt_covers_chest = TRUE
 	sensor_mode = SENSOR_COORDS
 	random_sensor = FALSE
+	var/obj/machinery/camera/builtInCamera = null
+	var/camera_on = TRUE
+
+/obj/item/clothing/under/rank/security/officer/Initialize()
+	. = ..()
+	if(!builtInCamera)
+		builtInCamera = new (src)
+		builtInCamera.network = list("ss13")
+		builtInCamera.internal_light = FALSE
+
+
+/obj/item/clothing/under/rank/security/officer/equipped(mob/user, slot)
+	. = ..()
+	if(builtInCamera)
+		var/obj/item/card/id/I = user.get_idcard(TRUE)
+		if(istype(I))
+			builtInCamera.c_tag = I.registered_name
+
+/obj/item/clothing/under/rank/security/officer/verb/toggle_camera()
+	set name = "Toggle Body Camera"
+	set category = "Object"
+	set src in usr
+	var/mob/M = usr
+	if (istype(M, /mob/dead/))
+		return
+	if (!can_use(M))
+		return
+	if(!builtInCamera)
+		to_chat(usr, "There is no camera!")
+		return 0
+
+	if(camera_on)
+		camera_on = FALSE
+		builtInCamera.status = 0
+	else
+		camera_on = TRUE
+		builtInCamera.status = 1
 
 /obj/item/clothing/under/rank/security/officer/grey
 	name = "grey security jumpsuit"

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -54,6 +54,11 @@
 //** -Adds security levels to the security record computer.
 //** -Adds arrest logging for security bots.
 //*************************************************************************
+
+
+//******************************************************
+//SEC BODY CAMS by Surrealistik Oct 2019 BEGINS
+//******************************************************
 /obj/item/clothing/under/rank/security
 	var/obj/machinery/camera/builtInCamera = null
 	var/registrant

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -56,6 +56,7 @@
 //*************************************************************************
 /obj/item/clothing/under/rank/security
 	var/obj/machinery/camera/builtInCamera = null
+	var/registrant
 	var/camera_on = TRUE
 	var/sound_time_stamp
 	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -54,3 +54,15 @@
 //** -Adds security levels to the security record computer.
 //** -Adds arrest logging for security bots.
 //*************************************************************************
+/obj/item/clothing/under/rank/security
+	var/obj/machinery/camera/builtInCamera = null
+	var/camera_on = TRUE
+	var/sound_time_stamp
+	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+
+/obj/machinery/computer/security
+	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
+
+//******************************************************
+//SEC BODY CAMS by Surrealistik Oct 2019 ENDS
+//******************************************************


### PR DESCRIPTION
### About The Pull Request
Per title. The name of the camera switches to that of the wearer's ID and role.

Anyone with sec access can see the body cam network from any security camera computer/console.

Body cameras can be toggled on or off.

A body camera will normally automatically register the name and role of its wearer's ID when equipped if that ID has Sec access. However, it can be manually changed by clicking on it with a Sec access ID/PDA

### Why It's Good For The Game

1. Allows Warden to better monitor and contribute to Security from his place at the brig; helps diminish the boredom of actually doing his job.
2. Adds realism/verisimilitude.
3. Allows Sec leadership to make sure their officers aren't being shit sec.
4. Allows for improved Sec coordination in general.

### Changelog
🆑
add: Security uniforms now have body cams that can be registered by clicking them with a Sec access ID/PDA, making them appear on the body camera network with the name and assignment on the ID. People with Sec access can see the body camera network from any security camera computer.
/🆑