### PR TITLE
Deputy and Heads Now Have Mindshield Implant and Can't be Most Antags

### DIFF
--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -23,9 +23,6 @@
 /datum/game_mode/clockwork_cult
 	restricted_jobs = list("Chaplain", "Captain", "Deputy")
 
-/datum/game_mode/cult
-	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Deputy")
-
 /datum/game_mode/traitor
 	restricted_jobs = list("Cyborg", "Deputy")
 
@@ -165,20 +162,45 @@
 
 
 //**************************************************
-//** NO ANTAG HOP PR - Surrealistik Oct 2019 BEGINS
+//** NO HEAD OR DEPUTY ANTAG PR - Surrealistik Oct 2019 BEGINS
 //**************************************************
 
 /datum/outfit/job/hop
 	implants = list(/obj/item/implant/mindshield)
 
+/datum/outfit/job/cmo
+	implants = list(/obj/item/implant/mindshield)
+
+/datum/outfit/job/ce
+	implants = list(/obj/item/implant/mindshield)
+
+/datum/outfit/job/rd
+	implants = list(/obj/item/implant/mindshield)
+
 /datum/game_mode/traitor
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
 
 /datum/game_mode/clockwork_cult
-	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
 
 /datum/game_mode/changeling
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
+
+/datum/game_mode/bloodsucker
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
+
+/datum/game_mode/cult
+	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
+
+/datum/dynamic_ruleset/midround/autotraitor
+	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
+
+/datum/dynamic_ruleset/latejoin/infiltrator
+	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
+
+/datum/dynamic_ruleset/roundstart/traitorbro
+	protected_roles = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Research Director", "Chief Medical Officer", "Chief Engineer", "Deputy")
+
 
 //**************************************************
 //** NO ANTAG HOP PR - Surrealistik Oct 2019 ENDS

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -162,3 +162,24 @@
 //** Adds no-collision holobeds to the medborg. Support for handheld versions
 //***************************************************************************
 
+
+
+//**************************************************
+//** NO ANTAG HOP PR - Surrealistik Oct 2019 BEGINS
+//**************************************************
+
+/datum/outfit/job/hop
+	implants = list(/obj/item/implant/mindshield)
+
+/datum/game_mode/traitor
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+
+/datum/game_mode/clockwork_cult
+	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+
+/datum/game_mode/changeling
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
+
+//**************************************************
+//** NO ANTAG HOP PR - Surrealistik Oct 2019 ENDS
+//**************************************************


### PR DESCRIPTION
## About The Pull Request

Antagging as Heads is far too easy, and the Heads are far too powerful/easy as an antag. This puts a stop to all of that.

Also bug fixes so that Deputies can't be antags as intended.

## Why It's Good For The Game

Heads as antags are cancerous, overpowered and unfun (except maybe for the antag) and this PR puts a stop to that.

People can now generally rely on their heads being trustworthy and reliable supervisors/instructors that won't abuse their authority and murder them.

Also this makes way more lore sense; it is utterly insane that HoP, the person who controls personnel and access, and is second only to the Captain, isn't specially vetted by Nanotrasen.

## Changelog
:cl:
balance: Heads and Deputy can no longer be most antags like the HoS and start with a mindshield implant.
/:cl: