### PR TITLE
Engiborg Basic Manipulator and Upgrade Added

### DIFF
--- a/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
+++ b/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
@@ -1,4 +1,6 @@
-#define ADVANCED_BORG_LIST list(/obj/item/circuitboard, /obj/item/stock_parts, /obj/item/tank, /obj/item/vending_refill)
+GLOBAL_LIST_INIT(basic_engiborg_manipulator_allowed, typecacheof(list(
+				/obj/item/wallframe,
+				/obj/item/electronics)))
 
 
 /obj/item/borg/upgrade/circuit_app/proc/upgrade_engiborg_manipulator(mob/living/silicon/robot/R, mob/user)
@@ -33,5 +35,5 @@
 		C.storable = list(/obj/item/wallframe,
 					/obj/item/electronics)
 		var/obj/item/stored_item = C.stored
-		if(stored_item in ADVANCED_BORG_LIST) //Drop stuff we can no longer hold.
+		if(is_type_in_typecache(stored_item, GLOB.basic_engiborg_manipulator_allowed)) //Drop stuff we can no longer hold.
 			stored_item.forceMove(get_turf(usr))

--- a/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
+++ b/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
@@ -1,3 +1,5 @@
+#define ADVANCED_BORG_LIST list(/obj/item/circuitboard, /obj/item/stock_parts, /obj/item/tank, /obj/item/vending_refill)
+
 
 /obj/item/borg/upgrade/circuit_app/proc/upgrade_engiborg_manipulator(mob/living/silicon/robot/R, mob/user)
 
@@ -12,10 +14,13 @@
 
 	C.upgraded = TRUE
 	C.name = "advanced component manipulation apparatus"
-	C.storable = list(/obj/item/circuitboard,
-			/obj/item/wallframe,
-			/obj/item/stock_parts,
-			/obj/item/electronics)
+	C.desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. This has been upgraded to also manipulate circuitboards, stock parts, gas tanks and vendor refills. Alt-Z or right-click to drop the stored object."
+	C.storable = list(/obj/item/wallframe,
+					/obj/item/electronics,
+					/obj/item/circuitboard,
+					/obj/item/stock_parts,
+					/obj/item/tank,
+					/obj/item/vending_refill)
 
 
 /obj/item/borg/upgrade/circuit_app/proc/remove_engiborg_manipulator_upgrade(mob/living/silicon/robot/R, mob/user)
@@ -23,6 +28,10 @@
 	var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
 	if(C && C.upgraded) //If upgraded, remove the upgrade
 		C.upgraded = FALSE
-		C.name = "basic component manipulation apparatus"
+		C.name = initial(C.name)
+		C.desc = initial(C.desc)
 		C.storable = list(/obj/item/wallframe,
 					/obj/item/electronics)
+		var/obj/item/stored_item = C.stored
+		if(stored_item in ADVANCED_BORG_LIST) //Drop stuff we can no longer hold.
+			stored_item.forceMove(get_turf(usr))

--- a/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
+++ b/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
@@ -1,23 +1,28 @@
 
 /obj/item/borg/upgrade/circuit_app/proc/upgrade_engiborg_manipulator(mob/living/silicon/robot/R, mob/user)
 
-	var/obj/item/borg/apparatus/circuit/basic/C = locate() in R.module.modules
-	if(C) //Delete the basic manipulator if we have it
-		qdel(C)
+	var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
+	if(!C)
+		to_chat(user, "<span class='warning'>This unit has no [C] to upgrade!</span>")
+		return FALSE
 
-	var/obj/item/borg/apparatus/circuit/advanced/A
-	A = new(R.module) //Add advanced manipulator
-	R.module.basic_modules += A
-	R.module.add_module(A, FALSE, TRUE)
+	if(C.upgraded) //Delete the basic manipulator if we have it
+		to_chat(user, "<span class='warning'>This unit already has an upgraded [C].</span>")
+		return FALSE
+
+	C.upgraded = TRUE
+	C.name = "advanced component manipulation apparatus"
+	C.storable = list(/obj/item/circuitboard,
+			/obj/item/wallframe,
+			/obj/item/stock_parts,
+			/obj/item/electronics)
 
 
 /obj/item/borg/upgrade/circuit_app/proc/remove_engiborg_manipulator_upgrade(mob/living/silicon/robot/R, mob/user)
 
-	var/obj/item/borg/apparatus/circuit/advanced/C = locate() in R.module.modules
-	if(C)
-		R.module.remove_module(C, TRUE)
-
-		var/obj/item/borg/apparatus/circuit/basic/B //Re-add the basic manipulator
-		B = new(R.module)
-		R.module.basic_modules += B
-		R.module.add_module(B, FALSE, TRUE)
+	var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
+	if(C && C.upgraded) //If upgraded, remove the upgrade
+		C.upgraded = FALSE
+		C.name = "basic component manipulation apparatus"
+		C.storable = list(/obj/item/wallframe,
+					/obj/item/electronics)

--- a/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
+++ b/code/FulpstationCode/fulp_cyborgs/cyborg_upgrades.dm
@@ -1,0 +1,23 @@
+
+/obj/item/borg/upgrade/circuit_app/proc/upgrade_engiborg_manipulator(mob/living/silicon/robot/R, mob/user)
+
+	var/obj/item/borg/apparatus/circuit/basic/C = locate() in R.module.modules
+	if(C) //Delete the basic manipulator if we have it
+		qdel(C)
+
+	var/obj/item/borg/apparatus/circuit/advanced/A
+	A = new(R.module) //Add advanced manipulator
+	R.module.basic_modules += A
+	R.module.add_module(A, FALSE, TRUE)
+
+
+/obj/item/borg/upgrade/circuit_app/proc/remove_engiborg_manipulator_upgrade(mob/living/silicon/robot/R, mob/user)
+
+	var/obj/item/borg/apparatus/circuit/advanced/C = locate() in R.module.modules
+	if(C)
+		R.module.remove_module(C, TRUE)
+
+		var/obj/item/borg/apparatus/circuit/basic/B //Re-add the basic manipulator
+		B = new(R.module)
+		R.module.basic_modules += B
+		R.module.add_module(B, FALSE, TRUE)

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -628,21 +628,25 @@
 /obj/item/borg/upgrade/circuit_app/action(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if(.)
+		upgrade_engiborg_manipulator(R, user) //Engineer Borg Manipulator Improvement by Surrealistik Oct 2019
+		/*
 		var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
 		if(C)
-			to_chat(user, "<span class='warning'>This unit is already equipped with a circuit apparatus!</span>")
+			to_chat(user, "<span class='warning'>This unit is already equipped with a [C].</span>")
 			return FALSE
 
 		C = new(R.module)
 		R.module.basic_modules += C
-		R.module.add_module(C, FALSE, TRUE)
+		R.module.add_module(C, FALSE, TRUE)*/
 
 /obj/item/borg/upgrade/circuit_app/deactivate(mob/living/silicon/robot/R, user = usr)
 	. = ..()
 	if (.)
+		remove_engiborg_manipulator_upgrade(R, user) //Engineer Borg Manipulator Improvement by Surrealistik Oct 2019
+		/*
 		var/obj/item/borg/apparatus/circuit/C = locate() in R.module.modules
 		if (C)
-			R.module.remove_module(C, TRUE)
+			R.module.remove_module(C, TRUE)*/
 
 /obj/item/borg/upgrade/beaker_app
 	name = "beaker storage apparatus"

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -77,6 +77,7 @@
 	desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. Alt-Z or right-click to drop the stored object."
 	var/upgraded = FALSE
 	storable = list(/obj/item/wallframe,
+				/obj/item/tank,
 				/obj/item/electronics)
 
 /obj/item/borg/upgrade/circuit_app

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -69,21 +69,14 @@
 		/obj/item/stack/sheet/rglass/cyborg,
 		/obj/item/stack/rods/cyborg,
 		/obj/item/stack/tile/plasteel/cyborg,
-		/obj/item/borg/apparatus/circuit/basic,
+		/obj/item/borg/apparatus/circuit,
 		/obj/item/stack/cable_coil/cyborg)
 
-/obj/item/borg/apparatus/circuit/basic
-	name = "basic component manipulation apparatus"
+/obj/item/borg/apparatus/circuit
+	name = "component manipulation apparatus"
 	desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. Alt-Z or right-click to drop the stored object."
+	var/upgraded = FALSE
 	storable = list(/obj/item/wallframe,
-				/obj/item/electronics)
-
-/obj/item/borg/apparatus/circuit/advanced
-	name = "advanced component manipulation apparatus"
-	desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. This one has been upgraded to handle stock parts and circuit boards. Alt-Z or right-click to drop the stored object."
-	storable = list(/obj/item/circuitboard,
-				/obj/item/wallframe,
-				/obj/item/stock_parts,
 				/obj/item/electronics)
 
 /obj/item/borg/upgrade/circuit_app

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -37,3 +37,62 @@
 
 /obj/item/clothing/suit/space/hardsuit
 	var/toggle_helmet_sound = 'sound/mecha/mechmove03.ogg'
+
+//*****************************************************************************
+//** Engineer Borg Manipulator Improvement by Surrealistik Oct 2019 BEGINS
+//** -------------------------------------------------------------------------
+//** Engiborgs now start with a manipulator for wall mounted frames and basic
+//** electronics which can be upgraded to hold stock parts and circuitboards
+//*****************************************************************************
+
+/obj/item/robot_module/engineering
+	basic_modules = list(
+		/obj/item/assembly/flash/cyborg,
+		/obj/item/borg/sight/meson,
+		/obj/item/construction/rcd/borg,
+		/obj/item/pipe_dispenser,
+		/obj/item/extinguisher,
+		/obj/item/weldingtool/largetank/cyborg,
+		/obj/item/screwdriver/cyborg,
+		/obj/item/wrench/cyborg,
+		/obj/item/crowbar/cyborg,
+		/obj/item/wirecutters/cyborg,
+		/obj/item/multitool/cyborg,
+		/obj/item/t_scanner,
+		/obj/item/analyzer,
+		/obj/item/geiger_counter/cyborg,
+		/obj/item/assembly/signaler/cyborg,
+		/obj/item/areaeditor/blueprints/cyborg,
+		/obj/item/electroadaptive_pseudocircuit,
+		/obj/item/stack/sheet/metal/cyborg,
+		/obj/item/stack/sheet/glass/cyborg,
+		/obj/item/stack/sheet/rglass/cyborg,
+		/obj/item/stack/rods/cyborg,
+		/obj/item/stack/tile/plasteel/cyborg,
+		/obj/item/borg/apparatus/circuit/basic,
+		/obj/item/stack/cable_coil/cyborg)
+
+/obj/item/borg/apparatus/circuit/basic
+	name = "basic component manipulation apparatus"
+	desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. Alt-Z or right-click to drop the stored object."
+	storable = list(/obj/item/wallframe,
+				/obj/item/electronics)
+
+/obj/item/borg/apparatus/circuit/advanced
+	name = "advanced component manipulation apparatus"
+	desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. This one has been upgraded to handle stock parts and circuit boards. Alt-Z or right-click to drop the stored object."
+	storable = list(/obj/item/circuitboard,
+				/obj/item/wallframe,
+				/obj/item/stock_parts,
+				/obj/item/electronics)
+
+/obj/item/borg/upgrade/circuit_app
+	name = "advanced component manipulation apparatus"
+	desc = "An engineering cyborg upgrade that improves the engineering cyborg manipulator, allowing it to manipulate circuitboards and stock parts."
+
+/datum/design/borg_upgrade_circuit_app
+	name = "Cyborg Upgrade (Component Manipulator Upgrade)"
+
+//*****************************************************************************
+//** Engineer Borg Manipulator Improvement by Surrealistik Oct 2019 ENDS
+//*****************************************************************************

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -73,7 +73,7 @@
 		/obj/item/stack/cable_coil/cyborg)
 
 /obj/item/borg/apparatus/circuit
-	name = "component manipulation apparatus"
+	name = "basic component manipulation apparatus"
 	desc = "A special apparatus for carrying and manipulating engineering components like electronics and wall mounted frames. Alt-Z or right-click to drop the stored object."
 	var/upgraded = FALSE
 	storable = list(/obj/item/wallframe,


### PR DESCRIPTION
## About The Pull Request
Adds a basic manipulator to the engiborg that can hold and use wall mounted frames and basic electronics.

The manipulator upgrade for the engiborg expands the functionality of the manipulator to handle circuit boards, stock parts, air/plasma tanks and vending machine refills.

## Why It's Good For The Game

Gives the engiborg basic functionalities it should have, but locks more advanced elements behind upgrades.

## Changelog
:cl:
add: Adds a basic manipulator to the engiborg that can hold and use wall mounted frames and basic electronics.
tweak: The manipulator upgrade for the engiborg expands the functionality of the manipulator to handle circuit boards, stock parts, air/plasma tanks and vending machine refills.
/:cl: