### PR TITLE
limit mech sets by manipulator tier

### DIFF
--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -21,20 +21,7 @@
 	var/link_on_init = TRUE
 	var/temp
 	var/datum/component/remote_materials/rmat
-	var/list/part_sets = list(
-								"Cyborg",
-								"Ripley",
-								"Firefighter",
-								"Odysseus",
-								"Gygax",
-								"Durand",
-								"H.O.N.K",
-								"Phazon",
-								"Exosuit Equipment",
-								"Exosuit Ammunition",
-								"Cyborg Upgrade Modules",
-								"Misc"
-								)
+	var/list/part_sets = list("Cyborg")
 
 /obj/machinery/mecha_part_fabricator/Initialize(mapload)
 	stored_research = new
@@ -59,6 +46,29 @@
 	//building time adjustment coefficient (1 -> 0.8 -> 0.6)
 	T = -1
 	for(var/obj/item/stock_parts/manipulator/Ml in component_parts)
+		// FULPSTATION: Tiered part sets 
+		
+		part_sets = list(
+								"Cyborg","Misc"
+								)	
+		if( Ml.rating >= 2)
+			part_sets += list(
+								"Ripley","Exosuit Equipment","Exosuit Ammunition","Cyborg Upgrade Modules"
+								)
+		if (Ml.rating >= 3)
+			part_sets += list(
+								"Firefighter","Odysseus","Gygax"
+								)
+		if (Ml.rating >= 4)
+			part_sets += list(
+								"Durand","H.O.N.K"
+								)
+		if (Ml.rating >= 5)
+			part_sets += list(
+								"Phazon"
+								)			
+		// END FULPSTATION: Tiered part sets 
+
 		T += Ml.rating
 	time_coeff = round(initial(time_coeff) - (initial(time_coeff)*(T))/5,0.01)
 

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -57,11 +57,11 @@
 								)
 		if (Ml.rating >= 3)
 			part_sets += list(
-								"Firefighter","Odysseus","Gygax"
+								"Firefighter","Odysseus"
 								)
 		if (Ml.rating >= 4)
 			part_sets += list(
-								"Durand","H.O.N.K"
+								"Durand","H.O.N.K","Gygax"
 								)
 		if (Ml.rating >= 5)
 			part_sets += list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
forces robotics to give a shit about stock parts

later I might try to add stock level requirements to mech components but thats not now

also, should this be on manips or lasers? lasers are the ones that actually make it more efficient. i'm banking on users just doing general stock upgrades atm
## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
make robotics care about stock parts. this will help ensure they dont waste resources on roundstart exosuits, will add pressure towards resourcing stock parts (which they have access to do if no scientist is present)
## Changelog
:cl:
tweak:In order to ensure operational efficiencies, Nanotrasen has ruled that it is necessary to limit what the robotics department is capable of fabricating based on the upgrades installed on the fabricator.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
