### PR TITLE
Cleans up icon updating for medborg organ bags

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/smartfridge.dm
@@ -98,6 +98,11 @@
 			return TRUE
 
 		if(istype(O, /obj/item/storage/bag) || istype(O, /obj/item/organ_storage)) //FULPSTATION MEDBORG ORGAN STORAGE FIX Surrealistik Nov 2019
+			if(istype(O, /obj/item/organ_storage)) //FULPSTATION MEDBORG ORGAN STORAGE TWEAK Surrealistik Jan 2020 BEGIN
+				O.icon_state = initial(O.icon_state) //We need to properly update the icon and overlays by reverting to our initial state.
+				O.desc = initial(O.desc)
+				O.cut_overlays()
+				O = O.contents[1] //FULPSTATION MEDBORG ORGAN STORAGE TWEAK Surrealistik Jan 2020 END
 			var/obj/item/storage/P = O
 			var/loaded = 0
 			for(var/obj/G in P.contents)


### PR DESCRIPTION
Per title. Medborg organ bag icons should update appropriately when depositing into a smartfridge.