### PR TITLE
Engiborg Electroadaptive Pseudocircuit Now Works With Airlocks

### DIFF
--- a/code/FulpstationCode/fulp_airlock_electroadaptive/fulp_airlock_electroadaptive_procs.dm
+++ b/code/FulpstationCode/fulp_airlock_electroadaptive/fulp_airlock_electroadaptive_procs.dm
@@ -1,0 +1,75 @@
+
+
+/obj/structure/door_assembly/proc/airlock_install_electroadaptive(obj/item/electroadaptive_pseudocircuit/W, mob/user)
+	if(!W.adapt_circuit(user, 15))
+		return
+
+	W.play_tool_sound(src, 100)
+	user.visible_message("<span class='notice'>[user] installs [W] into the airlock assembly.</span>", \
+						"<span class='notice'>You start to install [W] into the airlock assembly...</span>")
+
+	if(do_after(user, 40, target = src))
+		if( state != AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS )
+			return
+
+		to_chat(user, "<span class='notice'>You install the [W].</span>")
+		state = AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER
+		name = "near finished airlock assembly"
+		electronics = new /obj/item/electronics/airlock
+
+		electronics.accesses = W.accesses //Copy over pseudocircuit data
+		electronics.one_access = W.one_access
+		electronics.unres_sides = W.unres_sides
+
+
+/obj/item/electroadaptive_pseudocircuit/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
+													datum/tgui/master_ui = null, datum/ui_state/state = GLOB.hands_state)
+	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
+	if(!ui)
+		ui = new(user, src, ui_key, "airlock_electronics", name, 975, 420, master_ui, state)
+		ui.open()
+
+/obj/item/electroadaptive_pseudocircuit/ui_data()
+	var/list/data = list()
+	var/list/regions = list()
+
+	for(var/i in 1 to 7)
+		var/list/region = list()
+		var/list/accesses = list()
+		for(var/j in get_region_accesses(i))
+			var/list/access = list()
+			access["name"] = get_access_desc(j)
+			access["id"] = j
+			access["req"] = (j in src.accesses)
+			accesses[++accesses.len] = access
+		region["name"] = get_region_accesses_name(i)
+		region["accesses"] = accesses
+		regions[++regions.len] = region
+	data["regions"] = regions
+	data["oneAccess"] = one_access
+	data["unres_direction"] = unres_sides
+
+	return data
+
+/obj/item/electroadaptive_pseudocircuit/ui_act(action, params)
+	if(..())
+		return
+	switch(action)
+		if("clear")
+			accesses = list()
+			one_access = 0
+			. = TRUE
+		if("one_access")
+			one_access = !one_access
+			. = TRUE
+		if("set")
+			var/access = text2num(params["access"])
+			if (!(access in accesses))
+				accesses += access
+			else
+				accesses -= access
+			. = TRUE
+		if("direc_set")
+			var/unres_direction = text2num(params["unres_direction"])
+			unres_sides ^= unres_direction //XOR, toggles only the bit that was clicked
+			. = TRUE

--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -9,7 +9,7 @@
 	var/recharging = FALSE
 	var/circuits = 5 //How many circuits the pseudocircuit has left
 	var/static/recycleable_circuits = typecacheof(list(/obj/item/electronics/firelock, /obj/item/electronics/airalarm, /obj/item/electronics/firealarm, \
-	/obj/item/electronics/apc))//A typecache of circuits consumable for material
+	/obj/item/electronics/airlock, /obj/item/electronics/apc))//A typecache of circuits consumable for material | //ELECTROADAPTIVE PROCS FOR AIRLOCKS PR, Surrealistik Oct 2019
 
 /obj/item/electroadaptive_pseudocircuit/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
+++ b/code/game/objects/items/devices/electroadaptive_pseudocircuit.dm
@@ -9,7 +9,7 @@
 	var/recharging = FALSE
 	var/circuits = 5 //How many circuits the pseudocircuit has left
 	var/static/recycleable_circuits = typecacheof(list(/obj/item/electronics/firelock, /obj/item/electronics/airalarm, /obj/item/electronics/firealarm, \
-	/obj/item/electronics/airlock, /obj/item/electronics/apc))//A typecache of circuits consumable for material | //ELECTROADAPTIVE PROCS FOR AIRLOCKS PR, Surrealistik Oct 2019
+	/obj/item/electronics/airlock, /obj/item/electronics/apc))//A typecache of circuits consumable for material | //FULP ELECTROADAPTIVE PROCS FOR AIRLOCKS PR, Surrealistik Oct 2019
 
 /obj/item/electroadaptive_pseudocircuit/Initialize()
 	. = ..()

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -161,7 +161,7 @@
 			name = "near finished airlock assembly"
 			electronics = W
 
-	else if(istype(W, /obj/item/electroadaptive_pseudocircuit) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS ) //ELECTROADAPTIVE PROCS FOR AIRLOCKS PR, Surrealistik Oct 2019
+	else if(istype(W, /obj/item/electroadaptive_pseudocircuit) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS ) //FULP ELECTROADAPTIVE PROCS FOR AIRLOCKS PR, Surrealistik Oct 2019
 		airlock_install_electroadaptive(W, user)
 
 

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -161,6 +161,9 @@
 			name = "near finished airlock assembly"
 			electronics = W
 
+	else if(istype(W, /obj/item/electroadaptive_pseudocircuit) && state == AIRLOCK_ASSEMBLY_NEEDS_ELECTRONICS ) //ELECTROADAPTIVE PROCS FOR AIRLOCKS PR, Surrealistik Oct 2019
+		airlock_install_electroadaptive(W, user)
+
 
 	else if((W.tool_behaviour == TOOL_CROWBAR) && state == AIRLOCK_ASSEMBLY_NEEDS_SCREWDRIVER )
 		user.visible_message("<span class='notice'>[user] removes the electronics from the airlock assembly.</span>", \

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -203,3 +203,16 @@
 //***************************************************************************
 
 
+
+//************************************************************************
+//** Airlock Electroadaptive Psuedo Circuit BEGINS - Surrealistik Oct 2019
+//************************************************************************
+
+/obj/item/electroadaptive_pseudocircuit
+	var/list/accesses = list()
+	var/one_access = 0
+	var/unres_sides = 0 //unrestricted sides, or sides of the airlock that will open regardless of access
+
+//************************************************************************
+//** Airlock Electroadaptive Psuedo Circuit ENDS - Surrealistik Oct 2019
+//************************************************************************

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -839,6 +839,7 @@
 #include "code\FulpstationCode\halloween_costumes\zombie_rider.dm"
 #include "code\FulpstationCode\improved_record_security\fulp_improved_record_security.dm"
 #include "code\FulpstationCode\medborg_holobed\medborg_holobed.dm"
+#include "code\FulpstationCode\fulp_airlock_electroadaptive\fulp_airlock_electroadaptive_procs.dm"
 #include "code\game\alternate_appearance.dm"
 #include "code\game\atoms.dm"
 #include "code\game\atoms_movable.dm"


### PR DESCRIPTION
## About The Pull Request

Per title. You can now use the electroadaptive pseudocircuit to insert airlock electronics, and the pseudocircuit can now salvage airlock electronics.

Airlock access levels can be programmed by using the pseudocircuit while selected; this data will be copied over to the inserted airlock electronics.

## Why It's Good For The Game

Gives the electroadaptive pseudocircuit functionality it should have; now it can deal with all the basic electronic types.

## Changelog
:cl:
add: Engiborg electroadaptive pseudocircuit can now install airlock electronics, and program access levels by using the module while it's active.
/:cl: