### PR TITLE
Tweak for Borg Radio PR

### DIFF
--- a/code/FulpstationCode/borg_radio_files/borg_radio.dm
+++ b/code/FulpstationCode/borg_radio_files/borg_radio.dm
@@ -1,14 +1,93 @@
-/mob/living/silicon/robot/proc/borg_reset_radio()
+/mob/living/silicon/robot/proc/borg_clear_radio()
+
+	if(!istype(radio.keyslot)) //sanity
+		return FALSE
+
+	if(!istype(radio.keyslot, /obj/item/encryptionkey/borg)) //We only delete if we have a borg encryption key; eject otherwise.
+		var/atom/T = drop_location()//To hopefully prevent run time errors.
+		radio.keyslot.forceMove(T)
+		radio.keyslot = null
+		radio.recalculateChannels()
+		return FALSE
+
 	QDEL_NULL(radio.keyslot)
 	radio.keyslot = null
+	radio.recalculateChannels()
 
+	return TRUE
 
-/obj/item/robot_module/proc/borg_set_radio(obj/item/encryptionkey/B, frequency)
+/obj/item/robot_module/proc/borg_set_radio(radio_channel) //We add the appropriate encryption key and subspace channels
 	if(!loc || !istype(loc, /mob/living/silicon/robot)) //Sanity
 		return
 
 	var/mob/living/silicon/robot/R = loc
-	R.radio.keyslot = new B
+
+	if(!istype(R, /mob/living/silicon/robot))
+		return
+
+	if(R.radio.keyslot) //If there's already something there, abort.
+		return
+
+	if(!radio_channel) //If we don't have a channel, get one
+		radio_channel = R.borg_determine_channel()
+
+	if(!radio_channel) //If we somehow still don't have a channel abort.
+		return
+
+	R.radio.keyslot = new /obj/item/encryptionkey/borg
+	R.radio.keyslot.channels = list(radio_channel)
+	R.radio.keyslot.channels[radio_channel] |= 1
+	desc = "A standard encryption key for a cyborg. Typically programmed with an appropriate departmental access."
 
 	R.radio.subspace_transmission = TRUE
 	R.radio.recalculateChannels()
+	return TRUE
+
+/mob/living/silicon/robot/proc/borg_determine_channel()
+	if(!module) //sanity
+		return FALSE
+
+	if(istype(module, /obj/item/robot_module/medical))
+		return RADIO_CHANNEL_MEDICAL
+	if(istype(module, /obj/item/robot_module/engineering))
+		return RADIO_CHANNEL_ENGINEERING
+	if(istype(module, /obj/item/robot_module/security))
+		return RADIO_CHANNEL_SECURITY
+	if(istype(module, /obj/item/robot_module/peacekeeper))
+		return RADIO_CHANNEL_SECURITY
+	if(istype(module, /obj/item/robot_module/miner))
+		return RADIO_CHANNEL_SUPPLY
+	if(istype(module, /obj/item/robot_module/standard))
+		return RADIO_CHANNEL_SERVICE
+	if(istype(module, /obj/item/robot_module/janitor))
+		return RADIO_CHANNEL_SERVICE
+	if(istype(module, /obj/item/robot_module/clown))
+		return RADIO_CHANNEL_SERVICE
+	if(istype(module, /obj/item/robot_module/butler))
+		return RADIO_CHANNEL_SERVICE
+	if(istype(module, /obj/item/robot_module/syndicate))
+		return RADIO_CHANNEL_SYNDICATE
+
+
+/obj/item/radio/borg/proc/reactivate_integrated_borg_key(user)
+
+	var/mob/living/silicon/robot/R = loc
+	var/message = "<span class='warning'>This radio doesn't have any encryption keys!</span>"
+	if(istype(R, /mob/living/silicon/robot) && R.module)
+		var/obj/item/robot_module/M = R.module
+		if(M.borg_set_radio())
+			message = "<span class='notice'>You reactivate [R]'s integrated encryption key.</span>"
+
+	to_chat(user, "[message]")
+
+/obj/item/radio/borg/proc/deactivate_integrated_borg_key(user)
+	var/mob/living/silicon/robot/R = loc
+	if(!R)
+		return FALSE
+	if(R.borg_clear_radio())
+		to_chat(user, "<span class='notice'>You deactivate the integrated encryption key.</span>")
+		return TRUE
+
+/obj/item/encryptionkey/borg
+	name = "borg general encryption key"
+	icon_state = "bin_cypherkey"

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -395,18 +395,20 @@
 				SSradio.remove_object(src, GLOB.radiochannels[ch_name])
 				secure_radio_connections[ch_name] = null
 
+			if(deactivate_integrated_borg_key(user)) //FULPSTATION Borg Radio PR by Surrealistik Jan 2020; we delete all borg type encryption keys.
+				return
 
 			if(keyslot)
 				var/turf/T = get_turf(user)
 				if(T)
 					keyslot.forceMove(T)
 					keyslot = null
+				to_chat(user, "<span class='notice'>You pop out the encryption key in the radio.</span>") //FULPSTATION
 
 			recalculateChannels()
-			to_chat(user, "<span class='notice'>You pop out the encryption key in the radio.</span>")
 
 		else
-			to_chat(user, "<span class='warning'>This radio doesn't have any encryption keys!</span>")
+			reactivate_integrated_borg_key(user) //FULPSTATION Borg Radio PR by Surrealistik Jan 2020; we activate any borg type encryption keys if there are no existing keys.
 
 	else if(istype(W, /obj/item/encryptionkey/))
 		if(keyslot)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -174,9 +174,8 @@
 	if(shell)
 		GLOB.available_ai_shells -= src
 	else
-		if(T && istype(radio) && istype(radio.keyslot))
-			radio.keyslot.forceMove(T)
-			radio.keyslot = null
+		borg_clear_radio() //FULPSTATION Borg Radio PR by Surrealistik Jan 2020; we delete all borg type encryption keys.
+
 	qdel(wires)
 	qdel(module)
 	qdel(eye_lights)
@@ -981,7 +980,7 @@
 
 /mob/living/silicon/robot/proc/ResetModule()
 	SEND_SIGNAL(src, COMSIG_BORG_SAFE_DECONSTRUCT)
-	borg_reset_radio() //FULPSTATION BORG RADIOS by Surrealistik Jan 2020
+	borg_clear_radio() //FULPSTATION BORG RADIOS by Surrealistik Jan 2020
 	uneq_all()
 	shown_robot_modules = FALSE
 	if(hud_used)

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -123,43 +123,42 @@
 
 /obj/item/robot_module/medical/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_med, FREQ_MEDICAL)
+	borg_set_radio(RADIO_CHANNEL_MEDICAL)
 
 
 /obj/item/robot_module/engineering/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_eng, FREQ_ENGINEERING)
+	borg_set_radio(RADIO_CHANNEL_ENGINEERING)
 
 
 /obj/item/robot_module/security/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_sec, FREQ_SECURITY)
+	borg_set_radio(RADIO_CHANNEL_SECURITY)
 
 /obj/item/robot_module/peacekeeper/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_sec, FREQ_SECURITY)
+	borg_set_radio(RADIO_CHANNEL_SECURITY)
 
 
 /obj/item/robot_module/miner/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_mining, FREQ_SUPPLY)
-
+	borg_set_radio(RADIO_CHANNEL_SUPPLY)
 
 /obj/item/robot_module/clown/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_service, FREQ_SERVICE)
+	borg_set_radio(RADIO_CHANNEL_SERVICE)
 
 /obj/item/robot_module/standard/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_service, FREQ_SERVICE)
+	borg_set_radio(RADIO_CHANNEL_SERVICE)
 
 /obj/item/robot_module/janitor/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_service, FREQ_SERVICE)
+	borg_set_radio(RADIO_CHANNEL_SERVICE)
 
 /obj/item/robot_module/butler/do_transform_delay()
 	..()
-	borg_set_radio(/obj/item/encryptionkey/headset_service, FREQ_SERVICE)
+	borg_set_radio(RADIO_CHANNEL_SERVICE)
 
 
 //***********************************************************************


### PR DESCRIPTION
:cl:
fix: Encryption keys are no longer deleted if placed in a borg before they choose a module. Further, they are not deleted if the module is reset or the borg is destroyed. 
tweak: 'Free' integrated cyborg encryption keys given as part of a module can be activated/deactivated by using a screwdriver on an opened cyborg. While such a key is deactivated, another can be installed.
:cl: