### PR TITLE
Remove Intergalactic Common from Ash Walkers

### DIFF
--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -26,7 +26,8 @@
 
 /datum/antagonist/ashwalker/on_gain()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
-
+	owner.current.remove_language(/datum/language/common) //Ash walkers do not know Intergalactic Common
+	
 /datum/antagonist/ashwalker/on_removal()
 	UnregisterSignal(owner.current, COMSIG_MOB_EXAMINATE)
 

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -26,7 +26,7 @@
 
 /datum/antagonist/ashwalker/on_gain()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
-	
+
 /datum/antagonist/ashwalker/on_removal()
 	UnregisterSignal(owner.current, COMSIG_MOB_EXAMINATE)
 

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -26,7 +26,6 @@
 
 /datum/antagonist/ashwalker/on_gain()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, .proc/on_examinate)
-	owner.current.remove_language(/datum/language/common) //Ash walkers do not know Intergalactic Common
 	
 /datum/antagonist/ashwalker/on_removal()
 	UnregisterSignal(owner.current, COMSIG_MOB_EXAMINATE)

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -269,7 +269,7 @@ Key procs
 	spoken_languages = list(/datum/language/common = list(LANGUAGE_ATOM),
 							/datum/language/draconic = list(LANGUAGE_ATOM))
 
-/datum/language_holder/lizard/ash
+/datum/language_holder/lizard/ash //FULPSTATION: Ashwalkers don't know intergalactic common anymore (PR #244)
 	understood_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
 	spoken_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
 	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))

--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -270,7 +270,9 @@ Key procs
 							/datum/language/draconic = list(LANGUAGE_ATOM))
 
 /datum/language_holder/lizard/ash
-	selected_language = /datum/language/draconic
+	understood_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
+	spoken_languages = list(/datum/language/draconic = list(LANGUAGE_ATOM))
+	blocked_languages = list(/datum/language/common = list(LANGUAGE_ATOM))
 
 /datum/language_holder/monkey
 	understood_languages = list(/datum/language/common = list(LANGUAGE_ATOM),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ash walkers will now only be able to speak Draconic. For now, intergalactic common isn't completely blocked but that can be modified if needed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Ash walkers live in Lavaland and don't work for/know what Nanotransen is. They should only know their own species-specific language and not be able to communicate with humans that they've never seen before. Plus, this might add some incentive for diplomatic relations, since now one needs a lizardperson or universal recorder to talk with them. 

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Ash Walkers can no longer communicate with crew members using Intergalactic Common. Nanotransen recommends using lizardperson crewmembers for diplomatic discussions with this race.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
