### PR TITLE
Spider Egg Nerf

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -92,7 +92,7 @@
 /obj/structure/spider/eggcluster/process()
 	amount_grown += rand(0,2)
 	if(amount_grown >= 100)
-		var/num = rand(3,12)
+		var/num = rand(3,6)
 		for(var/i=0, i<num, i++)
 			var/obj/structure/spider/spiderling/S = new /obj/structure/spider/spiderling(src.loc)
 			S.faction = faction.Copy()


### PR DESCRIPTION
Attempt 2 at this PR. The nerf will reduce spider egg count to 3-6 rather than it's original 3-12 reducing the amount of spiderlings from an egg which should help when spiders become sentient from being an absolute steam roll.