### PR TITLE
Prototype fix

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/prototype.dmm
+++ b/_maps/RandomRuins/SpaceRuins/prototype.dmm
@@ -271,7 +271,7 @@
 "fk" = (/obj/structure/cable,/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/open/floor/wood/airless,/area/ruin/has_grav/prototype/Captain)
 "fl" = (/turf/open/space/basic,/turf/closed/wall/mineral/plastitanium/interior{icon_state = "d-nw"},/turf/closed/wall/mineral/plastitanium/interior{icon_state = "d-nw-0"},/area/ruin/space/has_grav/powered)
 "fm" = (/turf/open/floor/plasteel/airless,/area/ruin/has_grav/prototype/shallway)
-"fn" = (/obj/item/circuitboard/machine/stasis,/obj/item/circuitboard/machine/clonepod,/obj/item/circuitboard/machine/clonescanner,/obj/structure/closet/crate/secure/science,/obj/item/circuitboard/computer/cloning,/turf/template_noop,/area/ruin/has_grav/prototype/shallway)
+"fn" = (/obj/item/circuitboard/machine/stasis,/obj/structure/closet/crate/secure/science,/turf/template_noop,/area/ruin/has_grav/prototype/shallway)
 "fo" = (/turf/closed/wall/r_wall/rust,/area/ruin/has_grav/prototype/Captain)
 "fp" = (/obj/structure/lattice/catwalk,/obj/structure/cable,/turf/template_noop,/area/space/nearstation)
 "fq" = (/obj/structure/lattice/catwalk,/turf/template_noop,/area/space/nearstation)

--- a/_maps/RandomRuins/SpaceRuins/prototype.dmm
+++ b/_maps/RandomRuins/SpaceRuins/prototype.dmm
@@ -271,7 +271,7 @@
 "fk" = (/obj/structure/cable,/obj/machinery/firealarm{dir = 1; pixel_y = -24},/turf/open/floor/wood/airless,/area/ruin/has_grav/prototype/Captain)
 "fl" = (/turf/open/space/basic,/turf/closed/wall/mineral/plastitanium/interior{icon_state = "d-nw"},/turf/closed/wall/mineral/plastitanium/interior{icon_state = "d-nw-0"},/area/ruin/space/has_grav/powered)
 "fm" = (/turf/open/floor/plasteel/airless,/area/ruin/has_grav/prototype/shallway)
-"fn" = (/obj/item/circuitboard/machine/stasis,/obj/structure/closet/crate/secure/science,/turf/template_noop,/area/ruin/has_grav/prototype/shallway)
+"fn" = (/obj/item/circuitboard/machine/stasis,/obj/structure/closet/crate/secure/science,/obj/turf/template_noop,/area/ruin/has_grav/prototype/shallway)
 "fo" = (/turf/closed/wall/r_wall/rust,/area/ruin/has_grav/prototype/Captain)
 "fp" = (/obj/structure/lattice/catwalk,/obj/structure/cable,/turf/template_noop,/area/space/nearstation)
 "fq" = (/obj/structure/lattice/catwalk,/turf/template_noop,/area/space/nearstation)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This takes kokojo's syndie corps and fixes it to where you can open it in dream maker. currently it has cloning boards, which doesn't exist in the code, and dream maker has a tantrum. currently DnD has the same problem, but that is going to be fixed soon in a patch.

about the changlog there. it looks weird. i don't know why it made it like that. but it is not how i deleted things. guess github was confused. but the end result is what i wanted.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
makes prototype openable so i can steal things from it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked a few things: deleted cloning boards from prototype
fix: fixed a few things: prototype being unable to be opened in dream maker
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
