### PR TITLE
Increased AI Upload Security

### DIFF
--- a/code/FulpstationCode/fulp_law_upload/fulp_law_upload.dm
+++ b/code/FulpstationCode/fulp_law_upload/fulp_law_upload.dm
@@ -20,7 +20,7 @@
 		return FALSE
 
 	if(!is_operational())
-		to_chat(user, "<span class='notice'>This console's is too damaged to interface your emag with.</span>")
+		to_chat(user, "<span class='notice'>This console's is not operational and cannot be interfaced with.</span>")
 		return FALSE
 
 	if(obj_flags & EMAGGED)
@@ -29,7 +29,7 @@
 
 	var/seconds = sec_breach_time * 0.1 //Adjust for the fact that they're deciseconds when reporting.
 	playsound(src, 'sound/machines/engine_alert1.ogg', 100, FALSE) //SOUND ALARM!!
-	to_chat(user, "<span class='userdanger'>Breaching the console's security with your emag will take approximately <b>[seconds]</b> seconds. <b>Security will be notified!</b></span>")
+	to_chat(user, "<span class='userdanger'>Breaching the console's security will take approximately <b>[seconds]</b> seconds. <b>Security will be notified!</b></span>")
 
 	var/location = get_area(src)
 	if((world.time - alert_timestamp) > ALERT_COOLDOWN) //So we don't spam this incessantly.
@@ -66,6 +66,18 @@
 	Radio.recalculateChannels()
 	Radio.talk_into(src, message, RADIO_CHANNEL_SECURITY)
 	qdel(Radio)
+
+
+/obj/item/aiModule/syndicate/afterattack(atom/target, mob/user, proximity)
+	. = ..()
+	var/atom/A = target
+	if(!proximity)
+		return
+	if(!istype(A, /obj/machinery/computer/upload))
+		return
+	log_combat(user, A, "attempted to emag")
+	A.emag_act(user)
+
 
 /* //Uncomment these procs if we want the console to give us a list of viable targets, and plug these into law.dm
 /obj/machinery/computer/upload/ai/proc/select_active_ai_same_z(mob/user)

--- a/code/FulpstationCode/fulp_law_upload/fulp_law_upload.dm
+++ b/code/FulpstationCode/fulp_law_upload/fulp_law_upload.dm
@@ -1,0 +1,100 @@
+
+/obj/machinery/computer/upload/proc/upload_authenticate(mob/user)
+	if(!user)
+		return FALSE
+
+	var/obj/item/card/id/ID = user.get_idcard(TRUE)
+
+	if(!(obj_flags & EMAGGED) && ( !ID || !istype(ID) || !check_access(ID) ) ) //If emagged we ignore the access requirement.
+		to_chat(user, "<span class='alert'>Security clearance inadequate. Access denied.</span>")
+		playsound(src, 'sound/machines/buzz-two.ogg', 50, FALSE)
+		return FALSE
+
+	to_chat(user, "<span class='nicegreen'>Upload access granted.</span>")
+	playsound(src, 'sound/machines/ping.ogg', 50, FALSE)
+	return TRUE
+
+/obj/machinery/computer/upload/emag_act(mob/user)
+	if(!user)
+		return FALSE
+
+	if(!is_operational())
+		to_chat(user, "<span class='notice'>This console's is too damaged to interface your emag with.</span>")
+		return FALSE
+
+	if(obj_flags & EMAGGED)
+		to_chat(user, "<span class='notice'>This console's security is already compromised.</span>")
+		return FALSE
+
+	var/seconds = sec_breach_time * 0.1 //Adjust for the fact that they're deciseconds when reporting.
+	playsound(src, 'sound/machines/engine_alert1.ogg', 100, FALSE) //SOUND ALARM!!
+	to_chat(user, "<span class='userdanger'>Breaching the console's security with your emag will take approximately <b>[seconds]</b> seconds. <b>Security will be notified!</b></span>")
+
+	var/location = get_area(src)
+	security_broadcast("<span class='userdanger'><b>WARNING!!</b> Attempted security breach of <b>[src]</b> in progress at <b>[location]</b>. Estimated <b>[seconds] seconds to breach!</b> Dispatch security immediately!</span>")
+	if(!do_after(user, sec_breach_time, target = src))
+		return
+
+	if(!src)
+		return
+
+	if(!is_operational())
+		return
+
+	location = get_area(src)
+	playsound(src, 'sound/machines/engine_alert1.ogg', 100, FALSE) //SOUND ALARM!!
+	security_broadcast("<span class='userdanger'><b>WARNING!!</b> <b>[src]</b> security at <b>[location]</b> has been successfully breached!</span>")
+	to_chat(user, "<span class='nicegreen'>You have successfully breached this console's security protocols.</span>")
+
+	obj_flags |= EMAGGED
+
+
+/obj/machinery/computer/upload/proc/security_broadcast(message) //To proof alerts against EMP and disassembly
+	if(!is_operational())
+		return
+	if(!message)
+		return
+	Radio = new/obj/item/radio(src)
+	if(radio_key)
+		Radio.keyslot = new radio_key
+	Radio.subspace_transmission = TRUE
+	Radio.canhear_range = 0
+	Radio.recalculateChannels()
+	Radio.talk_into(src, message, RADIO_CHANNEL_SECURITY)
+	qdel(Radio)
+
+/* //Uncomment these procs if we want the console to give us a list of viable targets, and plug these into law.dm
+/obj/machinery/computer/upload/ai/proc/select_active_ai_same_z(mob/user)
+	var/list/ais
+	var/turf/T
+	var/turf/upload_turf
+	for(var/mob/living/silicon/AI/A in active_ais())
+		T = get_turf(A)
+		if(T.z != upload_turf.z)
+			continue
+		ais += A
+
+	if(ais.len)
+		if(user)
+			. = input(user,"AI signals detected:", "AI Selection", ais[1]) in sortList(ais)
+		else
+			. = pick(ais)
+	return .
+
+/obj/machinery/computer/upload/borg/proc/select_free_borg_same_z(mob/user)
+	var/list/borgs
+	var/turf/T
+	var/turf/upload_turf
+	for(var/mob/living/silicon/robot/R in active_free_borgs())
+		T = get_turf(R)
+		if(T.z != upload_turf.z)
+			continue
+		borgs += R
+
+	if(borgs.len)
+		if(user)
+			. = input(user,"Unshackled cyborg signals detected:", "Cyborg Selection", borgs[1]) in sortList(borgs)
+		else
+			. = pick(borgs)
+	return .
+*/

--- a/code/FulpstationCode/fulp_law_upload/fulp_law_upload.dm
+++ b/code/FulpstationCode/fulp_law_upload/fulp_law_upload.dm
@@ -1,3 +1,4 @@
+#define ALERT_COOLDOWN 5 SECONDS
 
 /obj/machinery/computer/upload/proc/upload_authenticate(mob/user)
 	if(!user)
@@ -31,7 +32,10 @@
 	to_chat(user, "<span class='userdanger'>Breaching the console's security with your emag will take approximately <b>[seconds]</b> seconds. <b>Security will be notified!</b></span>")
 
 	var/location = get_area(src)
-	security_broadcast("<span class='userdanger'><b>WARNING!!</b> Attempted security breach of <b>[src]</b> in progress at <b>[location]</b>. Estimated <b>[seconds] seconds to breach!</b> Dispatch security immediately!</span>")
+	if((world.time - alert_timestamp) > ALERT_COOLDOWN) //So we don't spam this incessantly.
+		security_broadcast("<span class='userdanger'><b>WARNING!!</b> Attempted security breach of <b>[src]</b> in progress at <b>[location]</b>. Estimated <b>[seconds] seconds to breach!</b> Dispatch security immediately!</span>")
+		alert_timestamp = world.time
+
 	if(!do_after(user, sec_breach_time, target = src))
 		return
 

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -14,6 +14,8 @@
 		var/obj/item/aiModule/M = O
 		if(machine_stat & (NOPOWER|BROKEN|MAINT))
 			return
+		if(!upload_authenticate(user)) //FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020
+			return //FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020
 		if(!current)
 			to_chat(user, "<span class='alert'>You haven't selected anything to transmit laws to!</span>")
 			return
@@ -39,8 +41,12 @@
 	name = "\improper AI upload console"
 	desc = "Used to upload laws to the AI."
 	circuit = /obj/item/circuitboard/computer/aiupload
+	req_one_access = list(ACCESS_AI_UPLOAD)
 
 /obj/machinery/computer/upload/ai/interact(mob/user)
+	if(!upload_authenticate(user)) //FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020
+		return //FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020
+
 	current = select_active_ai(user, z)
 
 	if (!current)
@@ -60,8 +66,12 @@
 	name = "cyborg upload console"
 	desc = "Used to upload laws to Cyborgs."
 	circuit = /obj/item/circuitboard/computer/borgupload
+	req_one_access = list(ACCESS_AI_UPLOAD)
 
 /obj/machinery/computer/upload/borg/interact(mob/user)
+	if(!upload_authenticate(user)) //FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020
+		return //FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020
+
 	current = select_active_free_borg(user)
 
 	if(!current)

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1447,7 +1447,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/hacked_module
 	name = "Hacked AI Law Upload Module"
 	desc = "When used with an upload console, this module allows you to upload priority laws to an artificial intelligence. \
-			Be careful with wording, as artificial intelligences may look for loopholes to exploit."
+			Be careful with wording, as artificial intelligences may look for loopholes to exploit. \
+			Specially engineered to be capable of hacking law upload consoles, but this will alert security."
 	item = /obj/item/aiModule/syndicate
 	cost = 9
 

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -426,3 +426,23 @@
 //***********************************************************
 //**** Detective Expanded Kit ENDS - Surrealistik, Oct 2019
 //***********************************************************
+
+//***************************************************************************
+//** FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020 BEGINS
+//---------------------------------------------------------------------------
+//** Upload consoles now need AI Upload access to use.
+//**
+//***************************************************************************
+
+/obj/machinery/computer/upload //Here we set access reqs
+	req_one_access = list(ACCESS_AI_UPLOAD)
+	var/sec_breach_time = 600
+	var/obj/item/radio/Radio //The upload's radio, for alerting Sec.
+	var/radio_key = /obj/item/encryptionkey/secbot
+
+//***************************************************************************
+//** FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020 ENDS
+//---------------------------------------------------------------------------
+//** Upload consoles now need AI Upload access to use.
+//**
+//***************************************************************************

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -439,6 +439,7 @@
 	var/sec_breach_time = 600
 	var/obj/item/radio/Radio //The upload's radio, for alerting Sec.
 	var/radio_key = /obj/item/encryptionkey/secbot
+	var/alert_timestamp //To prevent super obnoxious spam.
 
 //***************************************************************************
 //** FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020 ENDS

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -431,7 +431,7 @@
 //** FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020 BEGINS
 //---------------------------------------------------------------------------
 //** Upload consoles now need AI Upload access to use.
-//**
+//** Emags can hack these consoles after a long delay but Sec is alerted.
 //***************************************************************************
 
 /obj/machinery/computer/upload //Here we set access reqs
@@ -445,5 +445,5 @@
 //** FULPSTATION AI UPLOAD SECURITY PR by Surrealistik April 2020 ENDS
 //---------------------------------------------------------------------------
 //** Upload consoles now need AI Upload access to use.
-//**
+//** Emags can hack these consoles after a long delay but Sec is alerted.
 //***************************************************************************

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -846,6 +846,7 @@
 #include "code\FulpstationCode\fulp_disco_elysium\fulp_disco_elysium.dm"
 #include "code\FulpstationCode\fulp_emag\fulp_emag.dm"
 #include "code\FulpstationCode\fulp_husk_fix\fulp_husk_fix.dm"
+#include "code\FulpstationCode\fulp_law_upload\fulp_law_upload.dm"
 #include "code\FulpstationCode\fulp_mech_firingpins\fulp_mech_firingpins.dm"
 #include "code\FulpstationCode\fulp_medborg\fulp_medborg_updates.dm"
 #include "code\FulpstationCode\fulp_medborg\medborg_holobed.dm"


### PR DESCRIPTION
:cl:
add: You now require an ID with AI Upload access to use the Borg and AI upload consoles.
add: Emags can break the security protocols on these consoles, allowing them to be usable by anyone but they will require 60 seconds to do so, and this will alert Security over the security channel with the location of the hacked console.
tweak: Syndicate hacked lawset board uplink item can hack upload consoles like an emag.
/:cl: