### PR TITLE
TG/Other Fixes Great Valu Multipack

### DIFF
--- a/code/FulpstationCode/Fulp_traitor_items/traitor_chaplain.dm
+++ b/code/FulpstationCode/Fulp_traitor_items/traitor_chaplain.dm
@@ -195,7 +195,7 @@
 		return
 	spark_setup()
 	user.say(pick("It's treason then!", "So be it... Jedi.", "NO. NO. NO... <i>YOU</i> WILL DIE!!", "You underestimate the power of the Dark Side!", "My hate has made me powerful...","I AM THE SENATE!!", "If you will not be turned... you will be destroyed!!", "You will pay the price for your lack of vision!!", "Young fool, only now, at the end, do you understand.", "Your feeble skills are no match for the power of the Dark Side!", "POWAAHHH!!", "UNNNNLIMITEDDDD POWAHHHH!!", "And now, young Skywalker, you will die."))
-	var/mob/living/carbon/target = targets[1]
+	var/mob/living/target = targets[1]
 	if(get_dist(user,target)>range)
 		to_chat(user, "<span class='warning'>[target.p_theyre(TRUE)] too far away!</span>")
 		return
@@ -212,12 +212,10 @@
 
 	Bolt(user, target,damage,max_bounces,range, user)
 
-/obj/effect/proc_holder/spell/targeted/force_lightning/proc/Bolt(mob/origin,mob/target,bolt_energy,bounces,bolt_range,mob/user = usr)
+/obj/effect/proc_holder/spell/targeted/force_lightning/proc/Bolt(mob/origin, mob/target, bolt_energy, bounces, bolt_range, mob/user = usr)
 
 	if(bolt_energy < 1) //Stop if we would do no damage.
 		return
-
-
 
 	origin.Beam(target,icon_state="lightning[rand(1,12)]",time=5)
 	var/mob/living/current = target
@@ -245,6 +243,8 @@
 		current.visible_message("<span class='warning'>[current] absorbs the [src], remaining unharmed!</span>", "<span class='userdanger'>You absorb the [src], remaining unharmed!</span>")
 	else
 		current.electrocute_act(bolt_energy,"Force Lightning",1,bolt_flags)
+		if(!iscarbon(current)) //So we affect borgs and simple mobs properly.
+			current.adjustFireLoss(bolt_energy)
 		spark_system.attach(target)
 		spark_system.start()
 

--- a/code/FulpstationCode/sec_borg_files/fulp_sec_borg.dm
+++ b/code/FulpstationCode/sec_borg_files/fulp_sec_borg.dm
@@ -522,6 +522,15 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 
+/datum/techweb_node/cyborg_upg_combat
+	id = "cyborg_upg_med"
+	display_name = "Cyborg Upgrades: Combat"
+	description = "Combat upgrades for cyborgs."
+	prereq_ids = list("cyborg_upg_sec", "weaponry")
+	design_ids = list("borg_upgrade_e_gun_cooler", "borg_upgrade_e_gun_kill")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	export_price = 5000
+
 /mob/proc/check_for_item(typepath)
 	if(locate(typepath) in src)
 		return (locate(typepath) in src)

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -62,11 +62,11 @@
 		// FULPSTATION: Tiered part sets
 
 		part_sets = list(
-								"Cyborg", "Cyborg Upgrade Modules", "Exosuit Equipment","Misc", "Ripley",
+								"Cyborg", "Cyborg Upgrade Modules", "Misc"
 								)
 		if( Ml.rating >= 2)
 			part_sets += list(
-								"Firefighter",
+								"Exosuit Equipment", "Firefighter", "Ripley"
 								)
 		if (Ml.rating >= 3)
 			part_sets += list(

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -66,7 +66,7 @@
 								)
 		if( Ml.rating >= 2)
 			part_sets += list(
-								"Exosuit Equipment", "Firefighter", "Ripley"
+								"Exosuit Equipment", "Clarke", "Ripley"
 								)
 		if (Ml.rating >= 3)
 			part_sets += list(

--- a/code/game/mecha/mech_fabricator.dm
+++ b/code/game/mecha/mech_fabricator.dm
@@ -62,19 +62,19 @@
 		// FULPSTATION: Tiered part sets
 
 		part_sets = list(
-								"Cyborg","Misc"
+								"Cyborg", "Cyborg Upgrade Modules", "Exosuit Equipment","Misc", "Ripley",
 								)
 		if( Ml.rating >= 2)
 			part_sets += list(
-								"Ripley","Exosuit Equipment","Exosuit Ammunition","Cyborg Upgrade Modules"
+								"Firefighter",
 								)
 		if (Ml.rating >= 3)
 			part_sets += list(
-								"Firefighter","Odysseus"
+								"Odysseus"
 								)
 		if (Ml.rating >= 4)
 			part_sets += list(
-								"Durand","H.O.N.K","Gygax"
+								"Durand","H.O.N.K","Gygax", "Exosuit Ammunition"
 								)
 		if (Ml.rating >= 5)
 			part_sets += list(

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -134,18 +134,18 @@
 
 /obj/structure/closet/secure_closet/security/PopulateContents()
 	..()
-	new /obj/item/clothing/suit/armor/vest(src)
+	/*new /obj/item/clothing/suit/armor/vest(src) //FULPSTATION Improved Sec Starter Gear by Surrealistik Oct 2019
 	new /obj/item/clothing/head/helmet/sec(src)
 	new /obj/item/radio/headset/headset_sec(src)
 	new /obj/item/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
-	new /obj/item/flashlight/seclite(src)
+	new /obj/item/flashlight/seclite(src)*/ //FULPSTATION Improved Sec Starter Gear by Surrealistik Oct 2019
 
 /obj/structure/closet/secure_closet/security/sec
 
 /obj/structure/closet/secure_closet/security/sec/PopulateContents()
 	..()
-	new /obj/item/storage/belt/security/full(src)
+	// new /obj/item/storage/belt/security/full(src) //FULPSTATION Improved Sec Starter Gear by Surrealistik Oct 2019
 
 /obj/structure/closet/secure_closet/security/cargo
 

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -66,14 +66,15 @@
 			to_chat(user, "<span class='warning'>[target] is full.</span>")
 			return
 
-		var/refill = reagents.get_master_reagent_id()
+		//var/refill = reagents.get_master_reagent_id() //FULPSTATION FIXES by Surrealistik April 2020 This is a half-assed feature often mistaken as a bug that is utterly broken as hell. Good riddance
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this, transfered_by = user)
 		to_chat(user, "<span class='notice'>You transfer [trans] units of the solution to [target].</span>")
 
+		/* //FULPSTATION FIXES by Surrealistik April 2020 This is a half-assed feature often mistaken as a bug that is utterly broken as hell. Good riddance.
 		if(iscyborg(user)) //Cyborg modules that include drinks automatically refill themselves, but drain the borg's cell
 			var/mob/living/silicon/robot/bro = user
 			bro.cell.use(30)
-			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 600)
+			addtimer(CALLBACK(reagents, /datum/reagents.proc/add_reagent, refill, trans), 600)*/ //FULPSTATION FIXES by Surrealistik April 2020 This is a half-assed feature often mistaken as a bug that is utterly broken as hell. Good riddance.
 
 	else if(target.is_drainable()) //A dispenser. Transfer FROM it TO us.
 		if (!is_refillable())

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -633,6 +633,7 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/* //FULPSTATION FIX PACK by Surrealistik April 2020
 /datum/design/borg_upgrade_disablercooler
 	name = "Cyborg Upgrade (Rapid Disabler Cooling Module)"
 	id = "borg_upgrade_disablercooler"
@@ -640,7 +641,7 @@
 	build_path = /obj/item/borg/upgrade/disablercooler
 	materials = list(/datum/material/iron = 20000 , /datum/material/glass = 6000, /datum/material/gold = 2000, /datum/material/diamond = 2000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Modules")*/ //FULPSTATION FIX PACK by Surrealistik April 2020
 
 /datum/design/borg_upgrade_diamonddrill
 	name = "Cyborg Upgrade (Diamond Drill)"

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -27,8 +27,7 @@
 
 /datum/uplink_item/role_restricted/mech_firing_pin
 	name = "Concealed Weapon Bay (Mech Firing Pin Included)"
-	desc = "A handy firing pin that can only be installed into mech weapons. \
-			It also hides the equipped weapon from plain sight. \
+	desc = "A concealed weapon bay that hides an equipped mech weapon from plain sight. \
 			Only one can fit on a mecha. \
 			This one comes complete with a handy firing pin that can only be installed into mech weapons."
 	item = /obj/item/storage/box/syndicate/bundle_mech

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -387,11 +387,6 @@
 /obj/machinery/vending/wardrobe/sec_wardrobe
 	req_access = list(ACCESS_SECURITY) //We can now vend armor and helmets, so we need to protect the contents.
 
-/obj/structure/closet/secure_closet/security/PopulateContents()
-	..()
-	for(var/atom/movable/AM in src) //Empty to reduce locker bloat due to better on-spawn gear and expanded protolathe options; let the grand purge begin.
-		qdel(AM)
-
 //************************************************************
 //** Improved Sec Starter Gear by Surrealistik Oct 2019 ENDS
 //************************************************************


### PR DESCRIPTION
🆑
tweak: Removes remainder of sec locker bloat.
fix: Fixes TG removal of cyborg combat upgrade tech, so kill capacitors and energy gun cooling modules are buildable again.
remove: Gets rid of the techweb entry for the unused disabler cooler.
tweak: Basic exosuit fabricator functions like borg upgrades, can be now built without upgrades. Basic utility mechs and their gear are accessible at lower upgrade levels.
fix: Exosuit fabricator can now produce the new TG Clarke mecha which replaces the Firefighter.
fix: Fixes the Sith Starter Kit's force lightning so it now properly targets and affects borgs and simple mobs.
remove: Removed half-assed and overpowered Service borg reagent duplication 'feature'.
/🆑