### PR TITLE
Borg Chameleon Projector Improvement Patch

### DIFF
--- a/code/FulpstationCode/fulp_medborg/fulp_medborg_updates.dm
+++ b/code/FulpstationCode/fulp_medborg/fulp_medborg_updates.dm
@@ -1,11 +1,11 @@
-/datum/techweb_node/cyborg_upg_med
+/*/datum/techweb_node/cyborg_upg_med
 	id = "cyborg_upg_med"
 	display_name = "Cyborg Upgrades: Medical"
 	description = "Medical upgrades for cyborgs."
 	prereq_ids = list("adv_biotech")
 	design_ids = list("borg_upgrade_piercinghypospray", "borg_upgrade_expandedsynthesiser", "borg_upgrade_pinpointer", "borg_upgrade_surgicalprocessor", "borg_upgrade_beakerapp", "borg_upgrade_medbeam") //FULPSTATION MEDBORG UPGRADES by Surrealistik March 2020
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
-	export_price = 5000
+	export_price = 5000*/
 
 /datum/design/borg_upgrade_medbeam
 	name = "Cyborg Upgrade (Heal Beam)"

--- a/code/FulpstationCode/fulp_syndiborg_files/fulp_syndicate_medborg.dm
+++ b/code/FulpstationCode/fulp_syndiborg_files/fulp_syndicate_medborg.dm
@@ -103,7 +103,7 @@
 
 /obj/item/borg_chameleon/verb/reset_name()
 	set name = "Reset Disguise Name"
-	set category = "Object"
+	set category = "Robot Commands"
 	set src in view(1)
 
 	if(!issilicon(usr))

--- a/code/FulpstationCode/fulp_syndiborg_files/fulp_syndicate_medborg.dm
+++ b/code/FulpstationCode/fulp_syndiborg_files/fulp_syndicate_medborg.dm
@@ -3,6 +3,8 @@
 		return FALSE
 
 	var/list/borg_disguses_list = list(
+	"Use Data Buffer", \
+	"Random", \
 	"Clown", \
 	"Engineering", \
 	"Janitor", \
@@ -12,42 +14,110 @@
 	"Security", \
 	"Service", \
 	"Standard", \
-	"Cancel")
+	"Syndicate Assault", \
+	"Syndicate Medical", \
+	"Syndicate Saboteur")
 
 	var/choice = input(user,"Which borg module will you disguise as?","Chameleon Borg Disguise") as null|anything in borg_disguses_list
 	if(QDELETED(src) || user.stat || !in_range(user, src) || user.incapacitated() || !choice)
 		return FALSE
 
+	friendlyName = default_name //Reset to our default name data.
+
+	if(choice == "Random") //Random disguise, but we exclude the Data Buffer and Syndicate appearances
+		choice = pick("Medical", "Security", "Engineering", "Peacekeeper", "Janitor", "Clown", "Mining", "Service", "Standard")
+
 	switch(choice)
 		if("Medical")
-			disguise_text = "medical"
+			disguise_text = "Medical"
 			disguise = "medical"
 		if("Security")
-			disguise_text = "security"
+			disguise_text = "Security"
 			disguise = "sec"
 		if("Engineering")
-			disguise_text = "engineering"
+			disguise_text = "Engineering"
 			disguise = "engineer"
 		if("Peacekeeper")
-			disguise_text = "peacekeeper"
+			disguise_text = "Peacekeeper"
 			disguise = "peace"
 		if("Janitor")
-			disguise_text = "janitor"
+			disguise_text = "Janitor"
 			disguise = "janitor"
 		if("Clown")
-			disguise_text = "clown"
+			disguise_text = "Clown"
 			disguise = "clown"
 		if("Mining")
-			disguise_text = "miner"
+			disguise_text = "Mining"
 			disguise = pick("miner","minerOLD","spidermin")
 		if("Service")
-			disguise_text = "service"
+			disguise_text = "Service"
 			disguise = pick("service_f", "service_m", "brobot", "kent", "tophat")
 		if("Standard")
-			disguise_text = "standard"
-			disguise = pick("robot")
-		if("Cancel")
-			return FALSE
+			disguise_text = "Standard"
+			disguise = "robot"
+		if("Syndicate Assault")
+			disguise_text = "Syndicate Assault"
+			disguise = "synd_sec"
+		if("Syndicate Medical")
+			disguise_text = "Syndicate Medical"
+			disguise = "synd_medical"
+		if("Syndicate Saboteur")
+			disguise_text = "Syndicate Saboteur"
+			disguise = "synd_engi"
+		if("Use Data Buffer")
+			if(!buffer_disguise_text || !buffer_disguise || !buffer_name)
+				to_chat(user, "<span class='warning'>No data in [src] data buffer! Aborting.</span>")
+				return FALSE
+			friendlyName = buffer_name //Use our buffer data.
+			disguise = buffer_disguise
+			disguise_text = buffer_disguise_text
 
-	to_chat(user, "<span class='notice'>You are disguising as a Nanotrasen [disguise_text] borg...</span>")
+	to_chat(user, "<span class='notice'>You are disguising as the <b>[disguise_text]</b> borg <b>[friendlyName]</b>...</span>")
 	return TRUE
+
+/obj/item/borg_chameleon/afterattack(atom/A, mob/user, params)
+	. = ..()
+	targeted_disguise(A, user)
+
+/obj/item/borg_chameleon/proc/targeted_disguise(atom/A, mob/user)
+
+	if(!istype(A, /mob/living/silicon/robot)) //Target must be a borg.
+		return FALSE
+
+	if(!user) //Sanity
+		return FALSE
+
+	if((get_dist(A, user) > 7) || !(A in view(7, user)) )
+		to_chat(user, "<span class='warning'>Target is out of scanning range or cannot be clearly scanned.</span>")
+		return FALSE
+
+	var/mob/living/silicon/robot/R = A
+
+	buffer_disguise_text = R.module.name
+	buffer_disguise = A.icon_state
+	buffer_name = A.name
+
+	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
+	to_chat(user, "<span class='notice'>You scanned <b>[buffer_name]</b> and have buffered their identity for [src]'s disguises.</span>")
+	return TRUE
+
+/obj/item/borg_chameleon/verb/reset_name()
+	set name = "Reset Disguise Name"
+	set category = "Object"
+	set src in view(1)
+
+	if(!issilicon(usr))
+		to_chat(usr, "<span class='warning'>You can't do that!</span>")
+		return
+
+	if(usr.incapacitated())
+		return
+
+	default_name = pick(GLOB.ai_names) //Choose a new random name.
+	playsound(loc, 'sound/machines/beep.ogg', get_clamped_volume(), TRUE, -1)
+	to_chat(user, "<span class='notice'>[src]'s disguise alias has been reset to <b>[default_name]</b>.</span>")
+
+
+/datum/action/item_action/borg_chameleon
+	name = "Chameleon Disguise Menu"
+	desc = "Activates the chameleon disguise menu. <b>WARNING: Resets any active disguises.</b>"

--- a/code/FulpstationCode/sec_borg_files/fulp_sec_borg.dm
+++ b/code/FulpstationCode/sec_borg_files/fulp_sec_borg.dm
@@ -523,7 +523,7 @@
 	export_price = 5000
 
 /datum/techweb_node/cyborg_upg_combat
-	id = "cyborg_upg_med"
+	id = "cyborg_upg_cmb"
 	display_name = "Cyborg Upgrades: Combat"
 	description = "Combat upgrades for cyborgs."
 	prereq_ids = list("cyborg_upg_sec", "weaponry")

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -41,7 +41,7 @@
 
 /obj/item/borg_chameleon/equipped(mob/user)
 	. = ..()
-	disrupt(user)
+	//disrupt(user) //FULPSTATION BORG CHAMELEON PATCH by Surrealistik May 2020
 
 /obj/item/borg_chameleon/attack_self(mob/living/silicon/robot/user)
 	if (user && user.cell && user.cell.charge >  activationCost)

--- a/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
+++ b/code/modules/antagonists/nukeop/equipment/borgchameleon.dm
@@ -29,7 +29,7 @@
 
 /obj/item/borg_chameleon/Initialize()
 	. = ..()
-	friendlyName = pick(GLOB.ai_names)
+	default_name = pick(GLOB.ai_names) //We store our default name. FULPSTATION SYNDICATE MEDBORG UPDATE by Surrealistik March 2020
 
 /obj/item/borg_chameleon/Destroy()
 	listeningTo = null
@@ -81,7 +81,7 @@
 			animate(offset=f:offset-1, time=rand()*20+10)
 		if (do_after(user, 50, target=user) && user.cell.use(activationCost))
 			playsound(src, 'sound/effects/bamf.ogg', 100, TRUE, -6)
-			to_chat(user, "<span class='notice'>You are now disguised as the Nanotrasen [disguise_text] borg \"[friendlyName]\".</span>")  //FULPSTATION SYNDICATE MEDBORG UPDATE by Surrealistik March 2020
+			to_chat(user, "<span class='notice'>You are now disguised as the <b>[disguise_text]</b> borg <b>[friendlyName]</b>. </span>")  //FULPSTATION SYNDICATE MEDBORG UPDATE by Surrealistik March 2020
 			activate(user)
 		else
 			to_chat(user, "<span class='warning'>The chameleon field fizzles.</span>")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -309,7 +309,7 @@
 	display_name = "Cyborg Upgrades: Utility"
 	description = "Utility upgrades for cyborgs."
 	prereq_ids = list("adv_robotics")
-	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_disablercooler", "borg_upgrade_trashofholding", "borg_upgrade_advancedmop")
+	design_ids = list("borg_upgrade_thrusters", "borg_upgrade_selfrepair", "borg_upgrade_expand", "borg_upgrade_trashofholding", "borg_upgrade_advancedmop") //FULPSTATION Chameleon Patch by Surrealistk May 2020
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 
@@ -322,7 +322,7 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 
-/* //FULPSTATION MEDBORG UPGRADE TECHWEB FIX by Surrealistik April 2020. Added the entry to fulp_medborg_updates. Don't ask me why this is necessary; it doesn't appear in the techweb otherwise.
+//FULPSTATION MEDBORG UPGRADE TECHWEB FIX by Surrealistik April 2020. Added the entry to fulp_medborg_updates. Don't ask me why this is necessary; it doesn't appear in the techweb otherwise.
 /datum/techweb_node/cyborg_upg_med
 	id = "cyborg_upg_med"
 	display_name = "Cyborg Upgrades: Medical"
@@ -330,7 +330,7 @@
 	prereq_ids = list("adv_biotech")
 	design_ids = list("borg_upgrade_piercinghypospray", "borg_upgrade_expandedsynthesiser", "borg_upgrade_pinpointer", "borg_upgrade_surgicalprocessor", "borg_upgrade_beakerapp", "borg_upgrade_medbeam") //FULPSTATION MEDBORG UPGRADES by Surrealistik March 2020
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
-	export_price = 5000*/
+	export_price = 5000
 
 /datum/techweb_node/ai
 	id = "ai"

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -146,6 +146,7 @@
 		explosion(src, -1, 1, 3, 2, 0)
 		visible_message("<span class='boldwarning'>[src] explodes!!</span>")
 		return
+	var/atom/throw_target
 	if(t5 >= 15 && A.density && isliving(A)) //FULP: If T5 is greater than or equal to 15, run that fucker over and just keep on driving!
 		var/mob/living/D = A
 		var/atom/throw_target = get_edge_target_turf(D, pick(GLOB.cardinals))
@@ -158,7 +159,7 @@
 	// If the speed is higher than delay_multiplier throw the person on the wheelchair away
 	if(A.density && speed > delay_multiplier && has_buckled_mobs())
 		var/mob/living/H = buckled_mobs[1]
-		var/atom/throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))
+		throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))
 		unbuckle_mob(H)
 		H.throw_at(throw_target, 2, 3)
 		H.Knockdown(100)

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -146,7 +146,6 @@
 		explosion(src, -1, 1, 3, 2, 0)
 		visible_message("<span class='boldwarning'>[src] explodes!!</span>")
 		return
-	var/atom/throw_target
 	if(t5 >= 15 && A.density && isliving(A)) //FULP: If T5 is greater than or equal to 15, run that fucker over and just keep on driving!
 		var/mob/living/D = A
 		var/atom/throw_target = get_edge_target_turf(D, pick(GLOB.cardinals))
@@ -159,7 +158,7 @@
 	// If the speed is higher than delay_multiplier throw the person on the wheelchair away
 	if(A.density && speed > delay_multiplier && has_buckled_mobs())
 		var/mob/living/H = buckled_mobs[1]
-		throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))
+		var/atom/throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))
 		unbuckle_mob(H)
 		H.throw_at(throw_target, 2, 3)
 		H.Knockdown(100)

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -344,6 +344,11 @@
 //***************************************************************************
 /obj/item/borg_chameleon //List of available disguises
 	var/disguise_text //for feedback
+	var/default_name //Where we store our initial name.
+	var/buffer_name //for RA2 spy style scan of other borgs.
+	var/buffer_disguise //for RA2 spy style scan of other borgs.
+	var/buffer_disguise_text //for RA2 spy style scan of other borgs.
+	actions_types = list(/datum/action/item_action/borg_chameleon)
 
 
 /obj/item/reagent_containers/borghypo/syndicate

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -242,8 +242,6 @@
 /obj/item/borg/upgrade/pinpointer //Sec borg can now install the crew monitor/pinpointer module.
 	module_type = list(/obj/item/robot_module/medical, /obj/item/robot_module/syndicate_medical, /obj/item/robot_module/security)
 
-/datum/techweb_node/cyborg_upg_combat
-	design_ids = list("borg_upgrade_e_gun_cooler", "borg_upgrade_e_gun_kill")
 
 //***************************************************************************
 //** FULPSTATION SECBORG MODULE UPDATE by Surrealistik Jan 2020 BEGINS


### PR DESCRIPTION
:cl:
add: Borg Chameleon Projector can now scan and buffer identities of other borgs; this data is selected via the Use Buffer Data option.
add:  Borg Chameleon Projector now allows you to pick Syndicate disguises, in case you want to feint the ops team having an assault borg or scare someone off, etc.
tweak: Borg Chameleon Projector now has a Random disguise option; this picks one of the standard modules at random.
add: You can now reset the random name chosen for your disguises via the Reset Disguise Name verb.
tweak: Action button added to the Chameleon Projector.
fix: Fixes an issue with the syndi-medborg list.
/:cl:
