### PR TITLE
5*3=15, not 30

### DIFF
--- a/code/FulpstationCode/t5_parts.dm
+++ b/code/FulpstationCode/t5_parts.dm
@@ -190,19 +190,19 @@
 
 ///T5 Motorized wheelchair code///
 
-/obj/vehicle/ridden/wheelchair/motorized/proc/RunOver(var/mob/living/carbon/human/H)
+/obj/vehicle/ridden/wheelchair/motorized/proc/RunOver(var/mob/living/carbon/H)
 	var/bloodiness = 0
 	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
-	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", "<span class='userdanger'>[src] drives over you!</span>")
+	H.visible_message("<span class='danger'>[src] runs [H] over!</span>", "<span class='userdanger'>[src] runs you over!</span>")
 	playsound(loc, 'sound/effects/splat.ogg', 50, TRUE)
 
-	var/damage = rand(1,10) //Choose between 1 and 10, then use for damage calc applied to head, chest, legs and arms.
+	var/damage = rand(7,9) //Choose a number between 7 and 9, then use that number for the damage calculations applied to the head, chest, legs and arms.
 	H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD, H.run_armor_check(BODY_ZONE_HEAD, "melee"))
 	H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST, H.run_armor_check(BODY_ZONE_CHEST, "melee"))
 	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG, H.run_armor_check(BODY_ZONE_L_LEG, "melee"))
 	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_LEG, H.run_armor_check(BODY_ZONE_R_LEG, "melee"))
 	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_ARM, H.run_armor_check(BODY_ZONE_L_ARM, "melee"))
-	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM, H.run_armor_check(BODY_ZONE_R_ARM, "melee"))
+	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_R_ARM, H.run_armor_check(BODY_ZONE_R_ARM, "melee")) //in total, this will be 42-54 damage (before the application of melee armor)
 	if(islizard(H)) //If H (target) is a lizard, deal 0.5*var/damage to their tail. Sorry rico!
 		H.adjustOrganLoss(ORGAN_SLOT_TAIL, 0.5*damage)
 	H.Knockdown(85)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1075,7 +1075,7 @@
 		MB.RunOver(src)
 	else if(istype(AM, /obj/vehicle/ridden/wheelchair/motorized)) //are we being run over by a motorized wheelchair?
 		var/obj/vehicle/ridden/wheelchair/motorized/MW = AM
-		if(MW.t5 >= 15) //is that wheelchair fully upgraded with T5 parts?
+		if(MW.t5 >= 15 && !(MW.pulledby)) //is that wheelchair fully upgraded with T5 parts? also, is it NOT being pulled by someone?
 			MW.RunOver(src)
 	. = ..()
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1067,3 +1067,15 @@
 
 	if(shoes && !(HIDESHOES in obscured) && shoes.washed(washer))
 		update_inv_shoes()
+
+//FULP: This code used to be in human.dm, but we've moved it here (and improved it) so that mulebots and motorized wheelchairs can run over both humans AND monkeys (and xenos)
+/mob/living/carbon/Crossed(atom/movable/AM)
+	if(istype(AM, /mob/living/simple_animal/bot/mulebot)) //are we being run over by a mulebot?
+		var/mob/living/simple_animal/bot/mulebot/MB = AM
+		MB.RunOver(src)
+	else if(istype(AM, /obj/vehicle/ridden/wheelchair/motorized)) //are we being run over by a motorized wheelchair?
+		var/obj/vehicle/ridden/wheelchair/motorized/MW = AM
+		if(MW.t5 >= 15) //is that wheelchair fully upgraded with T5 parts?
+			MW.RunOver(src)
+	. = ..()
+

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -207,10 +207,10 @@
 // called when something steps onto a human
 // this could be made more general, but for now just handle mulebot
 /mob/living/carbon/human/Crossed(atom/movable/AM)
-	var/mob/living/simple_animal/bot/mulebot/MB = AM
+	/* var/mob/living/simple_animal/bot/mulebot/MB = AM
 	if(istype(MB))
-		MB.RunOver(src)
-
+		MB.RunOver(src) */
+//FULP: The code for running people over with mulebots has been moved to carbon.dm
 	. = ..()
 	spreadFire(AM)
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -669,7 +669,7 @@
 
 // called from mob/living/carbon/human/Crossed()
 // when mulebot is in the same loc
-/mob/living/simple_animal/bot/mulebot/proc/RunOver(mob/living/carbon/human/H)
+/mob/living/simple_animal/bot/mulebot/proc/RunOver(mob/living/carbon/H) //FULP: this used to assume that H was a human, but now H can be a monkey or something instead
 	log_combat(src, H, "run over", null, "(DAMTYPE: [uppertext(BRUTE)])")
 	H.visible_message("<span class='danger'>[src] drives over [H]!</span>", \
 					"<span class='userdanger'>[src] drives over you!</span>")

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -149,11 +149,16 @@
 	// If the speed is higher than delay_multiplier throw the person on the wheelchair away
 	if(A.density && speed > delay_multiplier && has_buckled_mobs())
 
-		if(t5 >= 30) //FULP: If T5 is greater than 30, run that fucker over!
+		if(t5 >= 15) //FULP: If T5 is greater than 15, run that fucker over and just keep on driving!
 			if(isliving(A))
-				RunOver(A)
+				var/mob/living/D = A
+				throw_target = get_edge_target_turf(D, pick(GLOB.cardinals))
+				D.throw_at(throw_target, 2, 3) //FULP: YEET
+				D.Knockdown(85)
+				D.adjustStaminaLoss(40) //FULP: Just like a mulebot, this does no damage on the initial hit- but it does LOADS of damage if you run a prone person over (see Crossed() in carbon.dm for the code for that))
+				D.visible_message("<span class='danger'>[src] rams into [D], sending [D] flying!</span>", "<span class='userdanger'>[src] rams you!</span>")
 				return
-		// If T5 (T5 identifier) is less than 30, execute as normal
+		// If T5 (T5 identifier) is less than 15, execute as normal
 
 		var/mob/living/H = buckled_mobs[1]
 		var/atom/throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -146,7 +146,7 @@
 		explosion(src, -1, 1, 3, 2, 0)
 		visible_message("<span class='boldwarning'>[src] explodes!!</span>")
 		return
-	if(t5 >= 15 && A.density && isliving(A)) //FULP: If T5 is greater than 15, run that fucker over and just keep on driving!
+	if(t5 >= 15 && A.density && isliving(A)) //FULP: If T5 is greater than or equal to 15, run that fucker over and just keep on driving!
 		var/mob/living/D = A
 		throw_target = get_edge_target_turf(D, pick(GLOB.cardinals))
 		D.throw_at(throw_target, 2, 3) //FULP: YEET

--- a/code/modules/vehicles/motorized_wheelchair.dm
+++ b/code/modules/vehicles/motorized_wheelchair.dm
@@ -146,20 +146,17 @@
 		explosion(src, -1, 1, 3, 2, 0)
 		visible_message("<span class='boldwarning'>[src] explodes!!</span>")
 		return
+	if(t5 >= 15 && A.density && isliving(A)) //FULP: If T5 is greater than 15, run that fucker over and just keep on driving!
+		var/mob/living/D = A
+		throw_target = get_edge_target_turf(D, pick(GLOB.cardinals))
+		D.throw_at(throw_target, 2, 3) //FULP: YEET
+		D.Knockdown(85)
+		D.adjustStaminaLoss(40) //FULP: Just like a mulebot, this does no damage on the initial hit- but it does LOADS of damage if you run a prone person over (see Crossed() in carbon.dm for the code for that))
+		D.visible_message("<span class='danger'>[src] rams into [D], sending [D] flying!</span>", "<span class='userdanger'>[src] rams you!</span>")
+		return
+	// FULP: If T5 (T5 identifier) is less than 15, execute as normal
 	// If the speed is higher than delay_multiplier throw the person on the wheelchair away
 	if(A.density && speed > delay_multiplier && has_buckled_mobs())
-
-		if(t5 >= 15) //FULP: If T5 is greater than 15, run that fucker over and just keep on driving!
-			if(isliving(A))
-				var/mob/living/D = A
-				throw_target = get_edge_target_turf(D, pick(GLOB.cardinals))
-				D.throw_at(throw_target, 2, 3) //FULP: YEET
-				D.Knockdown(85)
-				D.adjustStaminaLoss(40) //FULP: Just like a mulebot, this does no damage on the initial hit- but it does LOADS of damage if you run a prone person over (see Crossed() in carbon.dm for the code for that))
-				D.visible_message("<span class='danger'>[src] rams into [D], sending [D] flying!</span>", "<span class='userdanger'>[src] rams you!</span>")
-				return
-		// If T5 (T5 identifier) is less than 15, execute as normal
-
 		var/mob/living/H = buckled_mobs[1]
 		var/atom/throw_target = get_edge_target_turf(H, pick(GLOB.cardinals))
 		unbuckle_mob(H)


### PR DESCRIPTION
## About The Pull Request

Motorized wheelchairs that have been fully upgraded with tier 5 parts can now run people over, as intended. Like mulebots, they now deal no brute damage on the initial collision (aside from any damage that might result from someone being thrown into a wall or something), but can run prone people over for massive amounts of brute damage.

Mulebots and fully-upgraded wheelchairs can now run prone monkeys, xenos, and other carbons over, not just humans.

## Why It's Good For The Game

https://ytcropper.com/cropped/j25e97d583665de

## Changelog
:cl: ATHATH
fix: Fully-upgraded motorized wheelchairs can now run people over, as intended.
balance: Mulebots and fully-upgraded wheelchairs can now run prone monkeys, xenos, and other carbons over, not just humans.
/:cl:

Note of caution: This PR has not been tested yet.