### PR TITLE
QoL Improvement for Forensic Scanner + Forensic Data Disks

### DIFF
--- a/code/FulpstationCode/fulp_starter_gear/fulp_starter_gear.dm
+++ b/code/FulpstationCode/fulp_starter_gear/fulp_starter_gear.dm
@@ -167,3 +167,13 @@
 	build_path = /obj/item/melee/baton
 	category = list("Weapons")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/forensic_disk
+	name = "Forensic Data Disk"
+	desc = "A forensic data storage disk used with the detective's forensic scanner. Has read and write functionality."
+	id = "forensic_data_disk"
+	build_type = PROTOLATHE
+	materials = list(/datum/material/iron = 50, /datum/material/glass = 50)
+	build_path = /obj/item/disk/forensic
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/code/FulpstationCode/sec_expanded_loadouts/detective_scanner.dm
+++ b/code/FulpstationCode/sec_expanded_loadouts/detective_scanner.dm
@@ -57,8 +57,6 @@
 	update_icon()
 
 
-
-
 /obj/item/detective_scanner/verb/toggle_mode()
 	set name = "Print Forensic Scanner Report"
 	set category = "Object"
@@ -71,12 +69,43 @@
 	if(usr.incapacitated())
 		return
 
+	var/time_differential = world.time - print_time_stamp
+	if(time_differential < print_cooldown)
+		to_chat(usr, "<span class='warning'>[src] isn't yet ready to print! It will be ready in [(print_cooldown - time_differential) * 0.1] more seconds.</span>")
+		return
+
 	if(log.len && !scanning)
 		scanning = 1
-		to_chat(usr, "<span class='notice'>Printing report, please wait...</span>")
-		addtimer(CALLBACK(src, .proc/PrintReport), 30)
+		to_chat(usr, "<span class='notice'>[src] prints out its report...</span>")
+		print_time_stamp = world.time
+		PrintReport()
 	else
 		to_chat(usr, "<span class='notice'>The scanner has no logs or is in use.</span>")
+
+
+/obj/item/detective_scanner/verb/clear_logs()
+	set name = "Clear Forensic Scanner Logs"
+	set category = "Object"
+	set src in view(1)
+
+	if(!isliving(usr))
+		to_chat(usr, "<span class='warning'>You can't do that!</span>")
+		return
+
+	if(usr.incapacitated())
+		return
+
+	var/obj/item/card/id/I = usr.get_idcard(TRUE)
+
+	if(!I || !check_access(I))
+		to_chat(usr, "<span class='warning'>Inadequate security clearance. Access denied.</span>")
+		playsound(loc, SEC_RADIO_SCAN_SOUND_DENY, get_clamped_volume(), TRUE, -1)
+		return
+
+	to_chat(usr, "<span class='warning'>You purge the scanner's logs.</span>")
+	log = list()
+	playsound(loc, SEC_BODY_CAM_SOUND, get_clamped_volume(), TRUE, -1)
+
 
 
 /obj/item/detective_scanner/update_icon()
@@ -84,3 +113,46 @@
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
+
+/obj/item/detective_scanner/attackby(obj/item/W, mob/user, params)
+	if(!istype(W, /obj/item/disk/forensic))
+		return
+	var/obj/item/disk/forensic/F = W
+
+	var/obj/item/card/id/I = user.get_idcard(TRUE)
+
+	if(!I || !check_access(I))
+		to_chat(usr, "<span class='warning'>Inadequate security clearance. Access denied.</span>")
+		playsound(loc, SEC_RADIO_SCAN_SOUND_DENY, get_clamped_volume(), TRUE, -1)
+		return
+
+	if(!F.write_mode) //Copy the log to the disk if we're set to read mode.
+		F.disk_log = log
+		playsound(loc, SEC_BODY_CAM_SOUND, get_clamped_volume(), TRUE, -1)
+		to_chat(usr, "<span class='notice'>You copied the scanner's log to the disk.</span>")
+
+	else if(LAZYLEN(F.disk_log)) //So we don't accidentally overwrite the scanner logs with nothing
+		log = F.disk_log
+		playsound(loc, SEC_BODY_CAM_SOUND, get_clamped_volume(), TRUE, -1)
+		to_chat(usr, "<span class='notice'>You overwrote the scanner's log with the disk's contents.</span>")
+
+//Classic floppy back ups!
+/obj/item/disk/forensic
+	name = "forensic data disk"
+	icon_state = "datadisk0" //Gosh I hope syndies don't mistake them for the nuke disk.
+	desc = "Charmingly antiquated yet undeniably effective. Used to read and write data to and from the forensic scanner. Can be labeled with a pen."
+	var/list/disk_log = list()
+	var/write_mode = FALSE //This determines whether we read or write data from/to the forensic scanner
+	obj_flags = UNIQUE_RENAME //Allows us to name and identify the disk.
+
+
+/obj/item/disk/forensic/attack_self(mob/user)
+	if(!write_mode)
+		to_chat(usr, "<span class='notice'>You set [src] to write mode. It will now overwrite the forensic scanner's logs with its contents.</span>")
+		write_mode = TRUE
+
+	else
+		to_chat(usr, "<span class='notice'>You set [src] to read mode. It will now copy data from the forensic scanner's logs.</span>")
+		write_mode = FALSE
+
+	playsound(loc, 'sound/machines/click.ogg', get_clamped_volume(), TRUE, -1)

--- a/code/modules/detectivework/scanner.dm
+++ b/code/modules/detectivework/scanner.dm
@@ -60,10 +60,10 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		M.put_in_hands(P)
-		to_chat(M, "<span class='notice'>Report printed. Log cleared.</span>")
+		to_chat(M, "<span class='notice'>Report printed.</span>") //FULPSTATION DETECTIVE LOCKER PR Surrealistik April 2020
 
 	// Clear the logs
-	log = list()
+	//log = list() //FULPSTATION DETECTIVE LOCKER PR Surrealistik April 2020
 	scanning = 0
 
 /obj/item/detective_scanner/afterattack(atom/A, mob/user, params)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -572,7 +572,7 @@
 	id = "sec_basic"
 	display_name = "Basic Security Equipment"
 	description = "Standard equipment used by security."
-	design_ids = list("seclite", "pepperspray", "bola_energy", "zipties", "evidencebag", "sec_radio", "protolathe_handcuffs", "stun_baton", "sec_belt", "security_helmet", "security_armor", "security_uniform", "security_boots", "security_headset") //FULPSTATION Improved Sec Starter Gear by Surrealistik MAR 2020
+	design_ids = list("seclite", "pepperspray", "bola_energy", "zipties", "evidencebag", "sec_radio", "protolathe_handcuffs", "stun_baton", "sec_belt", "security_helmet", "security_armor", "security_uniform", "security_boots", "security_headset", "forensic_data_disk") //FULPSTATION Improved Sec Starter Gear by Surrealistik MAR 2020
 	prereq_ids = list("base")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 	export_price = 5000

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -390,6 +390,7 @@
 //************************************************************
 //** Improved Sec Starter Gear by Surrealistik Oct 2019 ENDS
 //************************************************************
+
 //***********************************************************
 //**** Detective Expanded Kit BEGINS - Surrealistik, Oct 2019
 //***********************************************************
@@ -410,10 +411,13 @@
 	desc = "Used to remotely scan objects and biomass for DNA and fingerprints, and has an integrated health and reagent analyzer. Can print a report of its findings."
 
 /obj/item/detective_scanner
-	var/mode
-	var/advanced = TRUE
 	icon = 'icons/Fulpicons/Surreal_stuff/detective_obs.dmi'
 	icon_state = "forensicnew-0"
+	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS) //Checked when trying to purge laws or use data disks with the scanner.
+	var/mode
+	var/advanced = TRUE
+	var/print_time_stamp
+	var/print_cooldown = 30 //3 second cooldown between prints.
 
 
 //***********************************************************


### PR DESCRIPTION
:cl:
tweak: Forensic Scanner no longer auto-wipes logs on print out. There is now a clear logs verb that requires appropriate access.
tweak: Forensic Scanner prints instantly now, but has a print cooldown of 3 seconds.
add: Forensic Data Disk added. Can be minted from the security techlathe. Can be labeled with the pen and set to read/write mode. Read mode copies data from the Forensic Scanner log to the disk when used on it. Write mode copies data from the disk to the scanner's log.
/:cl:
