### PR TITLE
Easier recipes for a few chems.

### DIFF
--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -155,7 +155,7 @@
 	required_catalysts = list(/datum/reagent/iron = 5)
 
 /datum/chemical_reaction/medsuture
-	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 20, /datum/reagent/medicine/polypyr = 15) //This might be a bit much, reagent cost should be reviewed after implementation.
+	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/toxin/formaldehyde = 10, /datum/reagent/medicine/C2/libital = 5)
 
 /datum/chemical_reaction/medsuture/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
@@ -163,7 +163,7 @@
 		new /obj/item/stack/medical/suture/medicated(location)
 
 /datum/chemical_reaction/medmesh
-	required_reagents = list(/datum/reagent/cellulose = 20, /datum/reagent/consumable/aloejuice = 20, /datum/reagent/space_cleaner/sterilizine = 10)
+	required_reagents = list(/datum/reagent/cellulose = 10, /datum/reagent/space_cleaner/sterilizine = 10, /datum/reagent/medicine/C2/aiuri = 5)
 
 /datum/chemical_reaction/medmesh/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -447,20 +447,30 @@
 
 //butterflium
 /datum/chemical_reaction/butterflium
-	required_reagents = list(/datum/reagent/colorful_reagent = 1, /datum/reagent/medicine/omnizine = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/nutriment = 1)
+	required_reagents = list(/datum/reagent/colorful_reagent = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/nutriment = 1)
 
 /datum/chemical_reaction/butterflium/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)
 	for(var/i = rand(1, created_volume), i <= created_volume, i++)
 		new /mob/living/simple_animal/butterfly(location)
 	..()
+
 //scream powder
 /datum/chemical_reaction/scream
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/consumable/cream = 5, /datum/reagent/consumable/ethanol/lizardwine = 5	)
-	required_temp = 374
+	required_reagents = list(/datum/reagent/medicine/C2/helbital = 1, /datum/reagent/drug/space_drugs = 1)
 
 /datum/chemical_reaction/scream/on_reaction(datum/reagents/holder, created_volume)
 	playsound(holder.my_atom, pick(list( 'sound/voice/human/malescream_1.ogg', 'sound/voice/human/malescream_2.ogg', 'sound/voice/human/malescream_3.ogg', 'sound/voice/human/malescream_4.ogg', 'sound/voice/human/malescream_5.ogg', 'sound/voice/human/malescream_6.ogg', 'sound/voice/human/femalescream_1.ogg', 'sound/voice/human/femalescream_2.ogg', 'sound/voice/human/femalescream_3.ogg', 'sound/voice/human/femalescream_4.ogg', 'sound/voice/human/femalescream_5.ogg', 'sound/voice/human/wilhelm_scream.ogg')), created_volume*5,TRUE)
+
+//mega scream powder
+/datum/chemical_reaction/scream/mega
+	required_reagents = list(/datum/reagent/medicine/C2/helbital = 2, /datum/reagent/toxin/fentanyl = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/sonic_powder = 1)
+
+/datum/chemical_reaction/scream/mega/on_reaction(datum/reagents/holder, created_volume)
+	playsound(holder.my_atom, pick(list( 'sound/voice/human/malescream_1.ogg', 'sound/voice/human/malescream_2.ogg', 'sound/voice/human/malescream_3.ogg', 'sound/voice/human/malescream_4.ogg', 'sound/voice/human/malescream_5.ogg', 'sound/voice/human/malescream_6.ogg', 'sound/voice/human/femalescream_1.ogg', 'sound/voice/human/femalescream_2.ogg', 'sound/voice/human/femalescream_3.ogg', 'sound/voice/human/femalescream_4.ogg', 'sound/voice/human/femalescream_5.ogg', 'sound/voice/human/wilhelm_scream.ogg')), created_volume*25,TRUE)
+	var/location = get_turf(holder.my_atom)
+	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume*2, location))
+		C.soundbang_act(1, 100, rand(0, 5))
 
 /datum/chemical_reaction/hair_dye
 	results = list(/datum/reagent/hair_dye = 5)


### PR DESCRIPTION
## About The Pull Request

Changes recipes for some chemicals.


**Medicated Suture:**
- Cellulose 10u.
- Formaldehyde 10u.
- Libital 5u.

**Advanced Regenerative Mesh:**
- Cellulose 10u.
- Sterilizine 10u.
- Aiuri 5u.

**Scream Powder:**
- Helbital 1u.
- Space Drugs 1u.

**Mega Scream Powder - _Makes a BIGGER scream and deafens in a small radius_:**
- Helbital 2u.
- Fentanyl 1u.
- Strange Reagent 1u. 
- Sonic Powder 1u.

**Butterflium:**
- Colorful Reagent 1u. 
- Strange Reagent 1u.
- Nutriment 1u.

## Why It's Good For The Game

Recipes for sutures and meshes were quite unbalanced rendering them useless.
And having impossible recipes for meme chemicals is just bad.

## Changelog
:cl:
add: Mega scream powder recipe: [Helbital 2u, Fentanyl 1u, Strange Reagent 1u, Sonic Powder 1u]
balance: Easier recipes for: Medicated Sutures, Advanced Regenerative Meshes, Scream Powder and Butterflium.
/:cl:
