### PR TITLE
Ventcrawl Vision

### DIFF
--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -328,7 +328,7 @@
 	return list()
 
 /obj/machinery/atmospherics/update_remote_sight(mob/user)
-	user.sight |= (SEE_TURFS)
+	user.sight |= (SEE_TURFS) //fulp edit
 
 //Used for certain children of obj/machinery/atmospherics to not show pipe vision when mob is inside it.
 /obj/machinery/atmospherics/proc/can_see_pipes()

--- a/code/modules/atmospherics/machinery/atmosmachinery.dm
+++ b/code/modules/atmospherics/machinery/atmosmachinery.dm
@@ -328,7 +328,7 @@
 	return list()
 
 /obj/machinery/atmospherics/update_remote_sight(mob/user)
-	user.sight |= (SEE_TURFS|BLIND)
+	user.sight |= (SEE_TURFS)
 
 //Used for certain children of obj/machinery/atmospherics to not show pipe vision when mob is inside it.
 /obj/machinery/atmospherics/proc/can_see_pipes()


### PR DESCRIPTION
Ventcrawling should now be back to it's old self. I decided to do this change as i absolutely hated when they made it so you were completely blind when ventcrawling making getting around the station as a swarmer really difficult. This should only make it so you can see the tiles it doesn't give you the ability to see people or objects.

