### PR TITLE
Sentience potions can be thrown

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -742,6 +742,11 @@
 
 /obj/item/slimepotion/slime/sentience/proc/after_success(mob/living/user, mob/living/simple_animal/SM)
 	return
+	
+/obj/item/slimepotion/throw_impact(atom/hit_atom, datum/thrownthing/throwingdatum)
+	. = ..()
+	if(!.) //if the bottle wasn't caught
+		attack(hit_atom, throwingdatum?.thrower)
 
 /obj/item/slimepotion/slime/sentience/nuclear
 	name = "syndicate intelligence potion"


### PR DESCRIPTION
## About The Pull Request

Simply calls throw_impact call attack. If that doesn't do what I think it does, feel free to correct.

## Why It's Good For The Game

For when you want that megafauna to wake up, but don't feel like getting close to it.

## Changelog
:cl:
tweak: Sentience potions can be thrown
/:cl: