### PR TITLE
Removes the Lavaland SecTech vendor

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -4955,9 +4955,6 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "UJ" = (
-/obj/machinery/vending/security{
-	onstation_override = 1
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Surreal's PR [https://github.com/TheSwain/Fulpstation/pull/299](url) in general moved sec loot to the brig or sec starting inventories. An exception to this is the poorly guarded SecTech vendor in Lavaland which, as a result of the PR, gained sechud sunglasses, sec bowman headsets and flashbangs. To access this vendor as non-sec, you need to hack just one door. To make things more consistent, this PR proposes to remove the vendor.

This is my first PR thus I may have made a mistake somewhere, or the idea might be terrible. Either way, I'm very open to resolving things with a civil discussion in the comments.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This PR removes an easy way for non-sec to obtain sec loot. Since Surreal's PR, obtaining flash protection as an antag has been much more interesting than just "let's loot the nearest sec locker" since you have to consider multiple options, most of which have downsides. Making it much more difficult to obtain sec bowman headsets has made the flashbang much more viable and made sec comms more secure, both of which have improved the sec experience. Both of these things make it more challenging for antags to "go loud" resulting in less witness kills, removing fewer people from the shift. The aim of this PR is to take these things a little further, improving the Fulp experience even more.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: Removed Lavaland SecTech vending machine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
