### PR TITLE
Fulp emag tweaks

### DIFF
--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -89,4 +89,4 @@
 			in electronic devices, subverts intended functions, and easily breaks security mechanisms.  \
 			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds."
 	item = /obj/item/card/emag/budget
-	cost = 6
+	cost = 4

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -90,3 +90,4 @@
 			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds."
 	item = /obj/item/card/emag/budget
 	cost = 4
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -86,8 +86,9 @@
 /datum/uplink_item/device_tools/budget_emag
 	name = "Budget Cryptographic Sequencer"
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
-			in electronic devices, subverts intended functions, and easily breaks security mechanisms.  \
-			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds."
+			in electronic devices, subverts intended functions, and easily breaks security mechanisms. \
+			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds. \
+			Cannot be used to open airlocks."
 	item = /obj/item/card/emag/budget
 	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -320,15 +320,18 @@
 
 //***************************************************************************
 //** FULPSTATION EMAG NERFS by Surrealistik Feb 2020 BEGINS
+//-- Ammendment: Fulp emag tweaks by Drackzo 21/6/20
 //---------------------------------------------------------------------------
 //** Makes the emag much more expensive and introduces a 6 TC budget emag
 //***************************************************************************
 
 /datum/uplink_item/device_tools/emag
-	cost = 15
+	cost = 4
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 //***************************************************************************
 //** FULPSTATION EMAG NERFS by Surrealistik Feb 2020 ENDS
+//-- Ammendment: Fulp emag tweaks by Drackzo 21/6/20
 //---------------------------------------------------------------------------
 //** Makes the emag much more expensive and introduces a 6 TC budget emag
 //***************************************************************************


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. The budget emag now costs 4tc and is available to traitors only.

2. "Cannot be used to open airlocks." has been added to the budget emag's description.

3. The full emag now costs 4tc and is available to operatives only.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1. Budget emag change: The price has been lowered to reflect the removal of its airlock functionality, 4tc is the price of TG's emag which I think is fair. Traitors get access to this rather than the full emag since the charge constraint rarely restricts them, plus it prevents someone emagging lots of machines like APCs quickly and causing more chaos than their objectives require. Operatives don't get access to this since they now have a version that's strictly better for the same price.

2. Budget emag description change: This ensures people don't buy the budget emag expecting it to open airlocks. TG added the same description to the full emag so I've added it to the budget for consistency.

3. Full emag change: The price has been significantly lowered since it was way too expensive before, considering the airlock functionality removal. Operatives get access to this since they may need to emag lots of things very quickly and should be allowed to, since it is within the scope of their objectives for them to cause wide scale chaos.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: budget emag cost reduced from 6 to 4tc and made traitor only
balance: full emag cost reduced from 15 to 4tc and made operative only
tweak: budget emag description changed to reflect its airlock functionality removal
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
