### PR TITLE
bye bye secborgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -332,7 +332,7 @@
 	magpulsing = TRUE
 	hat_offset = -4
 
-/obj/item/robot_module/security
+/* /obj/item/robot_module/security
 	name = "Security"
 	basic_modules = list(
 		/obj/item/assembly/flash/cyborg,
@@ -362,7 +362,7 @@
 			T.cell.give(S.e_cost * coeff)
 			T.update_icon()
 		else
-			T.charge_tick = 0
+			T.charge_tick = 0 */
 
 /obj/item/robot_module/peacekeeper
 	name = "Peacekeeper"


### PR DESCRIPTION
good fucking riddance

## About The Pull Request

Notes out the security borg module.

## Why It's Good For The Game

Don't need a reason, this is grudgecode at its finest. I got killed by a secborg who was given illegal tech by robotics as a space dragon, which made me incapable of killing it, this is a heavy imbalance and since borgs are fireproof, can't do anything against them on that front, gust doesn't KO borgs who have VTEC either so glad powergaming in robotics has been completely ignored by /tg/. Hell, /tg/ has this as a config option to be off but nobody thinks that removing the single most hated module in the game for cyborg on our server is a good idea.

## Changelog
:cl:
del: Removed the security module from cyborgs.
/:cl: