### PR TITLE
Nerfs forcefields

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -10,8 +10,8 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	custom_materials = list(/datum/material/iron=250, /datum/material/glass=500)
-	var/max_shield_integrity = 250
-	var/shield_integrity = 250
+	var/max_shield_integrity = 25
+	var/shield_integrity = 25
 	var/max_fields = 3
 	var/list/current_fields
 	var/field_distance_limit = 7


### PR DESCRIPTION
Whoever made this value so high deserves to be fucking lynched.

## About The Pull Request

Completely nerfs forcefields so they can't be used to stunlock those who you push into a near-inescapable prison where you can knock them down with your telebaton.

## Why It's Good For The Game

These are only used for greytide and grief. At least atmospheric forcefields have a purpose, these exist only for area denial and imprisonment.

## Changelog
:cl:
balance: Forcefields are now considerably weaker.
/:cl: