### PR TITLE
security station bounced radios now start with their speakers on

### DIFF
--- a/code/FulpstationCode/fulp_starter_gear/fulp_starter_gear.dm
+++ b/code/FulpstationCode/fulp_starter_gear/fulp_starter_gear.dm
@@ -23,6 +23,7 @@
 	icon_state = "sec_radio"
 	desc = "A sophisticated full range station bounced radio. Preconfigured with a radio frequency for emergency security use in the event of telecom disruption. You can use a Security ID to reset its frequency to the emergency security channel."
 	freerange = TRUE //Can access the full spectrum
+	listening = TRUE //starts with its speaker on, so you can actually hear your fellow officers remind you about the existence of these when comms go down
 	subspace_switchable = TRUE
 	req_one_access = list(ACCESS_SECURITY, ACCESS_FORENSICS_LOCKERS)
 	custom_materials = list(/datum/material/iron = 500, /datum/material/glass = 250)
@@ -177,3 +178,4 @@
 	build_path = /obj/item/disk/forensic
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+	


### PR DESCRIPTION
## About The Pull Request

Security station bounced radios (the ones that start the shift in your belt, not the headsets that start the shift on your ears) now start the shift with their speakers on. Their microphones will still start the shift off.

## Why It's Good For The Game

Security station bounced radios are currently quite unreliable, since not every officer will remember to turn them on at roundstart, and it's kind of hard to remind them to turn them on if the comms network is down.

Plus, as long as nobody's spamming the special security station bounced radio channel, there's not really a reason to NOT turn on your security station bounced radio's speaker at shiftstart, so why not make it turn itself(/its own speaker) on automatically?

## Changelog
:cl: ATHATH
tweak: Security station bounced radios (the ones that start the shift in your belt, not the headsets that start the shift on your ears) now start the shift with their speakers on. Their microphones will still start the shift off.
/:cl: