### PR TITLE
Nerfs cult stun, gives Security huds instead

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,22 +436,28 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
-									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 
-		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(16 SECONDS)
-			L.flash_act(1,TRUE)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(1.5 SECONDS)
+				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -461,8 +461,8 @@
 					C.stuttering += 15
 					C.cultslurring += 15
 					C.Jitter(15)
-		uses--
-	..()
+			uses--
+		..()
 
 //Teleportation
 /obj/item/melee/blood_magic/teleport

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -440,7 +440,6 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
-			else
 			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 				var/mob/living/carbon/C = L
 				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -440,27 +440,27 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
-		else
-			to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
-			C.stuttering += 8
-			C.dizziness += 30
-			C.Jitter(8)
-			C.drop_all_held_items()
-			C.bleed(40)
-			C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
-		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(160)
-			L.flash_act(1,1)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(15)
+			else
+				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -441,7 +441,7 @@
 		else
 			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 				var/mob/living/carbon/C = L
-				to_chat(user, "<span class='cultitalic'>Their mind was too strong, but it leaves a damaging effect!</span>")
+				to_chat(user, "<span class='cultitalic'>Their mind was too strong, but it leaves a damaging effect nonetheless!</span>")
 				C.stuttering += 10
 				C.dizziness += 25
 				C.Jitter(8)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -442,27 +442,27 @@
 
 		else
 			to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
-				C.stuttering += 8
-				C.dizziness += 30
-				C.Jitter(8)
-				C.drop_all_held_items()
-				C.bleed(40)
-				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
-			else
-				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-				L.Paralyze(160)
-				L.flash_act(1,1)
-				if(issilicon(target))
-					var/mob/living/silicon/S = L
-					S.emp_act(EMP_HEAVY)
-				else if(iscarbon(target))
-					var/mob/living/carbon/C = L
-					C.silent += 6
-					C.stuttering += 15
-					C.cultslurring += 15
-					C.Jitter(15)
-			uses--
-		..()
+			C.stuttering += 8
+			C.dizziness += 30
+			C.Jitter(8)
+			C.drop_all_held_items()
+			C.bleed(40)
+			C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+		else
+			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+			L.Paralyze(160)
+			L.flash_act(1,1)
+			if(issilicon(target))
+				var/mob/living/silicon/S = L
+				S.emp_act(EMP_HEAVY)
+			else if(iscarbon(target))
+				var/mob/living/carbon/C = L
+				C.silent += 6
+				C.stuttering += 15
+				C.cultslurring += 15
+				C.Jitter(15)
+		uses--
+	..()
 
 //Teleportation
 /obj/item/melee/blood_magic/teleport

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -441,6 +441,8 @@
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
 			else
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+				var/mob/living/carbon/C = L
 				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
 				C.stuttering += 8
 				C.dizziness += 30

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -435,23 +435,32 @@
 				var/obj/item/ams_object = anti_magic_source
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
+
 			else
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
 		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(16 SECONDS)
-			L.flash_act(1,TRUE)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(1.5 SECONDS)
+			to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -441,9 +441,9 @@
 		else
 			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 				var/mob/living/carbon/C = L
-				to_chat(user, "<span class='cultitalic'>Their mind was too strong, but it still left a damaging effect!</span>")
-				C.stuttering += 8
-				C.dizziness += 30
+				to_chat(user, "<span class='cultitalic'>Their mind was too strong, but it leaves a damaging effect!</span>")
+				C.stuttering += 10
+				C.dizziness += 25
 				C.Jitter(8)
 				C.drop_all_held_items()
 				C.bleed(30)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -435,7 +435,6 @@
 				var/obj/item/ams_object = anti_magic_source
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
-
 			else
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,28 +436,22 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
-				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
-				C.stuttering += 8
-				C.dizziness += 30
-				C.Jitter(8)
-				C.drop_all_held_items()
-				C.bleed(40)
-				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
-			else
-				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-				L.Paralyze(160)
-				L.flash_act(1,1)
-				if(issilicon(target))
-					var/mob/living/silicon/S = L
-					S.emp_act(EMP_HEAVY)
-				else if(iscarbon(target))
-					var/mob/living/carbon/C = L
-					C.silent += 6
-					C.stuttering += 15
-					C.cultslurring += 15
-					C.Jitter(15)
+		else
+			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+			L.Paralyze(16 SECONDS)
+			L.flash_act(1,TRUE)
+			if(issilicon(target))
+				var/mob/living/silicon/S = L
+				S.emp_act(EMP_HEAVY)
+			else if(iscarbon(target))
+				var/mob/living/carbon/C = L
+				C.silent += 6
+				C.stuttering += 15
+				C.cultslurring += 15
+				C.Jitter(1.5 SECONDS)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -438,15 +438,15 @@
 			else
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
-
+		else
 			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 				var/mob/living/carbon/C = L
-				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				to_chat(user, "<span class='cultitalic'>Their mind was too strong, but it still left a damaging effect!</span>")
 				C.stuttering += 8
 				C.dizziness += 30
 				C.Jitter(8)
 				C.drop_all_held_items()
-				C.bleed(40)
+				C.bleed(30)
 				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
 			else
 				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -433,7 +433,7 @@
 	icon_state = "blindfold"
 	inhand_icon_state = "blindfold"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-    hud_trait = TRAIT_SECURITY_HUD
+		hud_trait = TRAIT_SECURITY_HUD
 	flash_protect = FLASH_PROTECTION_FLASH
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -433,7 +433,7 @@
 	icon_state = "blindfold"
 	inhand_icon_state = "blindfold"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-		hud_trait = TRAIT_SECURITY_HUD
+	hud_trait = TRAIT_SECURITY_HUD
 	flash_protect = FLASH_PROTECTION_FLASH
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -432,6 +432,8 @@
 	name = "zealot's blindfold"
 	icon_state = "blindfold"
 	inhand_icon_state = "blindfold"
+	hud_type = DATA_HUD_SECURITY_ADVANCED
+    	hud_trait = TRAIT_SECURITY_HUD
 	flash_protect = FLASH_PROTECTION_FLASH
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -433,7 +433,7 @@
 	icon_state = "blindfold"
 	inhand_icon_state = "blindfold"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
-    	hud_trait = TRAIT_SECURITY_HUD
+    hud_trait = TRAIT_SECURITY_HUD
 	flash_protect = FLASH_PROTECTION_FLASH
 
 /obj/item/clothing/glasses/hud/health/night/cultblind/equipped(mob/living/user, slot)


### PR DESCRIPTION
## About The Pull Request

This nerfs the cult's stun ability, causing mindshielded people to drop held items, jitter/stutter, bleed 5% of their blood and take stamina damage (2 cult stuns back to back will result in stamcrit), while keeping the stun for non mindshielded people.
To slightly balance this out, I gave the Zealot's blindfold Security huds rather than Medical, so they could tell if someone is mindshielded if they want to take the risk of wearing it in public.

## Why It's Good For The Game

The cult stun should be for early game converting and not for winning fights against armed Security Officers lategame.
Also, unless the cult's target is the Chaplain, all it takes is one click to take your target out. This way, even if their target isn't the Chaplain, it still won't just take one click to win.
/tg/ justified that this nerf was bad because "Cult doesn't have security huds", so the blindfold is my compromise

## Changelog
:cl:
balance: Cult stun causes mindshielded people to jitter rather than stun
balance: Zealot's blindfold has SecHUD rather than MedHUD
/:cl: