### PR TITLE
Singularity Hammer Damage Buff

### DIFF
--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -72,7 +72,7 @@
 			charged = FALSE
 			if(istype(A, /mob/living/))
 				var/mob/living/Z = A
-				Z.take_bodypart_damage(20,0)
+				Z.take_bodypart_damage(35,0)
 			playsound(user, 'sound/weapons/marauder.ogg', 50, TRUE)
 			var/turf/target = get_turf(A)
 			vortex(target,user)


### PR DESCRIPTION




## About The Pull Request

Changes the Singulo Hammer's wielded damage from 20 to 35 brute. 

## Why It's Good For The Game

The Singulo Hammer is currently in a sad place, being totally overshadowed by the mjolnir. Coupled with the mjolnir nerf, I think that buffing the Singulo Hammer might encourage people to use it over the mjolnir, and add some variety to wizard rounds.

## Changelog
:cl:
balance: Singulo Hammer now hits harder.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
