### PR TITLE
Changes Emag price to 6tc, Removes Budget Emag from Uplink

### DIFF
--- a/code/FulpstationCode/fulp_emag/fulp_emag.dm
+++ b/code/FulpstationCode/fulp_emag/fulp_emag.dm
@@ -1,4 +1,4 @@
-/obj/item/card/emag/budget
+/obj/item/card/emag/budget //Guess we can keep it in the code for now, just in case Surreal finds a way to tweak it back, or we manage a compromise. -SgtHunk. (August 2020)
 	desc = "It's a card with a magnetic strip attached to some circuitry. This one appears to be a crude knockoff with a digital counter on closer inspection."
 	name = "budget cryptographic sequencer"
 	var/charges = 2

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1381,7 +1381,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
 			in electronic devices, subverts intended functions, and easily breaks security mechanisms. Cannot be used to open airlocks."
 	item = /obj/item/card/emag
-	cost = 4
+	cost = 6
 
 /datum/uplink_item/device_tools/syndie_jaws_of_life
 	name = "Syndicate Jaws of Life"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1381,7 +1381,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
 			in electronic devices, subverts intended functions, and easily breaks security mechanisms. Cannot be used to open airlocks."
 	item = /obj/item/card/emag
-	cost = 6
+	cost = 4
 
 /datum/uplink_item/device_tools/syndie_jaws_of_life
 	name = "Syndicate Jaws of Life"

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -87,6 +87,7 @@
 	name = "Budget Cryptographic Sequencer"
 	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
 			in electronic devices, subverts intended functions, and easily breaks security mechanisms.  \
-			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds."
+			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds.  \
+			Cannot be used to open airlocks."
 	item = /obj/item/card/emag/budget
-	cost = 6
+	cost = 2

--- a/code/modules/uplink/uplink_items_fulp.dm
+++ b/code/modules/uplink/uplink_items_fulp.dm
@@ -82,12 +82,3 @@
 	include_modes = list(/datum/game_mode/nuclear/clown_ops)
 	item = /obj/structure/closet/crate/laser_tag_partypack_blue
 	cost = 50
-
-/datum/uplink_item/device_tools/budget_emag
-	name = "Budget Cryptographic Sequencer"
-	desc = "The cryptographic sequencer, electromagnetic card, or emag, is a small card that unlocks hidden functions \
-			in electronic devices, subverts intended functions, and easily breaks security mechanisms.  \
-			This is a cheap knockoff Space-China budget version that holds 2 charges, and regains 1 charge every 30 seconds.  \
-			Cannot be used to open airlocks."
-	item = /obj/item/card/emag/budget
-	cost = 2

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -320,12 +320,13 @@
 
 //***************************************************************************
 //** FULPSTATION EMAG NERFS by Surrealistik Feb 2020 BEGINS
+//** Lowers price of Emag as per Door opening feature removal. -SgtHunk
 //---------------------------------------------------------------------------
-//** Makes the emag much more expensive and introduces a 6 TC budget emag
+//** Makes the emag much more expensive and introduces a 6tc budget emag
 //***************************************************************************
 
 /datum/uplink_item/device_tools/emag
-	cost = 15
+	cost = 4
 
 //***************************************************************************
 //** FULPSTATION EMAG NERFS by Surrealistik Feb 2020 ENDS

--- a/code/zFulpstationCode/fulp_overwrite_vars.dm
+++ b/code/zFulpstationCode/fulp_overwrite_vars.dm
@@ -320,13 +320,14 @@
 
 //***************************************************************************
 //** FULPSTATION EMAG NERFS by Surrealistik Feb 2020 BEGINS
-//** Lowers price of Emag as per Door opening feature removal. -SgtHunk
+//** Lowers price of Emag as per Door opening feature removal AND
+//** Removes Budget Emag due to its... inability to be balanced. -SgtHunk (August 2020)
 //---------------------------------------------------------------------------
-//** Makes the emag much more expensive and introduces a 6tc budget emag
+//** Makes the emag much more expensive and introduces a 6 TC budget emag
 //***************************************************************************
 
 /datum/uplink_item/device_tools/emag
-	cost = 4
+	cost = 6
 
 //***************************************************************************
 //** FULPSTATION EMAG NERFS by Surrealistik Feb 2020 ENDS

--- a/code/zFulpstationCode/traitor_overwrites.dm
+++ b/code/zFulpstationCode/traitor_overwrites.dm
@@ -1,0 +1,3 @@
+// For all your Traitor-related var overwrites!
+// That way none of us have to bother with whatever conflicts arise.
+// And also so we don't have to overwrite the variables defined in TG code.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3281,6 +3281,7 @@
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
 #include "code\zFulpstationCode\fulp_overwrite_vars.dm"
+#include "code\zFulpstationCode\traitor_overwrites.dm"
 #include "code\zFulpstationCode\wizard_spells_disabler.dm"
 #include "interface\interface.dm"
 #include "interface\menu.dm"


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lowers Normal Emag's price to 6tc, and Removes Budget Emag from Uplink.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The only reason Emag was so expensive was because of people that would use it to spam open airlocks and cheese it. Now that it no longer can, the price should be changed back to how it was. (TG has it on 4TC, and yes, I do know that this is similar to Drack's Emag tweak PR that got lost in between the stale closed PRs.)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked Emag's price, as it's price change was mostly due to being able to spam open airlocks (Which it can't now)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
