### PR TITLE
Adds Replica Katana to Heliostation

### DIFF
--- a/_maps/map_files/Heliostation/heliostation.dmm
+++ b/_maps/map_files/Heliostation/heliostation.dmm
@@ -37549,6 +37549,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/toy/katana,
 /turf/open/floor/plasteel,
 /area/crew_quarters/lounge)
 "bjQ" = (


### PR DESCRIPTION
## About The Pull Request

It adds the Replica katana to Heliostation

## Why It's Good For The Game

The replica katana is a fun item on every other map

## Changelog

:cl:
add: adds replica katana to heliostation
/:cl:
