### PR TITLE
Adds new function on the Communications Console, allows any Mod+ to call ERT if requested

### DIFF
--- a/code/FulpstationCode/fulp_procs.dm
+++ b/code/FulpstationCode/fulp_procs.dm
@@ -60,3 +60,12 @@
 	for(var/obj/effect/landmark/S in GLOB.xeno_spawn)
 		if(get_area(S) == dept)
 			return S
+
+// ERT time?
+
+/proc/ERT_request(text , mob/Sender)
+	var/msg = copytext_char(sanitize(text), 1, MAX_MESSAGE_LEN)
+	msg = "<span class='adminnotice'><b><font color=orange>CENTCOM:</font>[ADMIN_FULLMONTY(Sender)] [ADMIN_CENTCOM_REPLY(Sender)] [ADMIN_ERT]:</b> [msg]</span>"
+	to_chat(GLOB.admins, msg, confidential = TRUE)
+	for(var/obj/machinery/computer/communications/C in GLOB.machines)
+		C.overrideCooldown()

--- a/code/__DEFINES/FulpDefines.dm
+++ b/code/__DEFINES/FulpDefines.dm
@@ -64,3 +64,7 @@ GLOBAL_LIST_EMPTY(mouths_beefman)//, list( "Smile1", "Smile2", "Frown1", "Frown2
 
 #define SYNTHFLESH_HUSKFIX_THRESHOLD 40 //For instabitaluri/synthflesh; allows maxed patches to heal burn husking.
 #define FULP_SURGERY_SPEEDMOD_MULTIPLIER 2 //Used to adjust the speed bonus provided by surgery step speed bonuses; higher is faster.
+
+//For our Mods to be able to call ERT :) -SgtHunk
+
+#define ADMIN_ERT "(<a href='?_src_=holder;[HrefToken(TRUE)];spawn_ert=1'>ERT</a>)"

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -331,6 +331,20 @@
 				priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self-Destruct Codes Requested",'sound/ai/commandreport.ogg')
 				CM.lastTimeUsed = world.time
 
+		if("ertrequest") //Finally, send in the SWAT
+			if(authenticated==2)
+				if(!checkCCcooldown())
+					to_chat(usr, "<span class='warning'>Arrays recycling. Please stand by.</span>")
+					return
+				var/input = stripped_input(usr, "Please enter the reason for requesting personnel from CentCom.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response.", "Send a message to CentCom.", "")
+				if(!input || !(usr in view(1,src)) || !checkCCcooldown())
+					return
+				ERT_request(input, usr)
+				to_chat(usr, "<span class='notice'>Request sent.</span>")
+				usr.log_message("has requested CentCom personnel from CentCom with reason \"[input]\"", LOG_SAY)
+				CM.lastTimeUsed = world.time
+
+
 
 		// AI interface
 		if("ai-main")
@@ -494,6 +508,7 @@
 					dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=nukerequest'>Request Nuclear Authentication Codes</A> \]"
 					if(!(obj_flags & EMAGGED))
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=MessageCentCom'>Send Message to CentCom</A> \]"
+						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=ertrequest'>Request CentCom personnel</A> \]"
 					else
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=MessageSyndicate'>Send Message to \[UNKNOWN\]</A> \]"
 						dat += "<BR>\[ <A HREF='?src=[REF(src)];operation=RestoreBackup'>Restore Backup Routing Data</A> \]"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2021,6 +2021,14 @@
 			SD.r_code = code
 		message_admins("[key_name_admin(usr)] has set the self-destruct \
 			code to \"[code]\".")
+	else if(href_list["spawn_ert"])
+		if(!check_rights(R_ADMIN))
+			return
+		makeEmergencyresponseteam()
+		message_admins("[key_name_admin(usr)] is creating an emergency \
+		response team.")
+
+
 
 	else if(href_list["add_station_goal"])
 		if(!check_rights(R_ADMIN))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

NOTE: This was more of me messing around. It's not expected to be merged.

This adds the new Admin command "ERT" which instantly redirects to the Create Antagonist -> Emergency Response Team section.
This new command appears after the new Communications console function (which requires Captain level access) is used, called "Request CentCom Personnel". This allows Admins to send in ERTs and its subtypes. INCLUDING CentCom Officials.

![image](https://user-images.githubusercontent.com/68669754/91255519-f13e6280-e732-11ea-8cfd-e153da6bf598.png)


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

![image](https://user-images.githubusercontent.com/68669754/91255367-a290c880-e732-11ea-9e63-bdc5e71ffe2d.png)

Makes sending ERTs slightly easier, and makes requesting them a separate thing than simply contacting CentCom.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added "Request CentCom Personnel" function for Communications console.
add: Added "ERT" Admin command to go with the mentioned above function, in case the higher ups wish to send any ERT and its subtypes (ERP, CentCom Official, Interns, etc)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
