### PR TITLE
Removes chameleon kit from Clown Ops

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1188,7 +1188,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			Due to budget cuts, the shoes don't provide protection against slipping."
 	item = /obj/item/storage/box/syndie_kit/chameleon
 	cost = 2
-	exclude_modes = list(/datum/game_mode/nuclear) //clown ops are allowed to buy this kit, since it's basically a costume
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/stealthy_tools/chameleon_proj
 	name = "Chameleon Projector"


### PR DESCRIPTION
## About The Pull Request

disables the chameleon kit for clown ops

## Why It's Good For The Game

Chameleon Kit is very overpowered for clown ops. It already was removed from nuke ops, but it was allowed for clown ops since it was sort of clown related. It is way too overpowered to be allowed just because it was clown related. With the chameleon kit as Clown Op you can walk straight up to the captain and there is no way for him to know that you are a Clown Op and not a crew member. Then all you have to do is take out your weapon from your backpack and kill the captain and win. Nuke/Clown Ops is all about the captain working with the crew to defend the nuke disk. However when the clown ops have a chameleon kit and could be the crew you basically have to run away from every other person you see in case they are a nuke op. Removing the chameleon kit will make Clown Ops more fair and allow the crew to work together like was intended.

## Changelog
:cl:
balance: disables chameleon kit from clown ops uplink
/:cl:
