### PR TITLE
Fixes a few gamebreaking Bloodsucker problems

### DIFF
--- a/code/modules/antagonists/bloodsucker/powers/bs_mesmerize.dm
+++ b/code/modules/antagonists/bloodsucker/powers/bs_mesmerize.dm
@@ -91,11 +91,12 @@
 	var/mob/living/user = owner
 
 	if (istype(target))
-		ADD_TRAIT(target, TRAIT_MUTE, "bloodsucker_mesmerize")
+		return
 
 	if (do_mob(user, target, 40, 0, TRUE, extra_checks=CALLBACK(src, .proc/ContinueActive, user, target)))
 		PowerActivatedSuccessfully() // PAY COST! BEGIN COOLDOWN!
 		var/power_time = 90 + level_current * 15
+		ADD_TRAIT(target, TRAIT_MUTE, "bloodsucker_mesmerize")
 		to_chat(user, "<span class='notice'>[target] is fixed in place by your hypnotic gaze.</span>")
 		target.Immobilize(power_time)
 		//target.silent += power_time / 10 // Silent isn't based on ticks.

--- a/code/modules/antagonists/bloodsucker/powers/bs_mesmerize.dm
+++ b/code/modules/antagonists/bloodsucker/powers/bs_mesmerize.dm
@@ -91,7 +91,7 @@
 	var/mob/living/user = owner
 
 	if (istype(target))
-		return
+		to_chat(user, "<span class='notice'>You attempt to hypnotically gaze [target].</span>")
 
 	if (do_mob(user, target, 40, 0, TRUE, extra_checks=CALLBACK(src, .proc/ContinueActive, user, target)))
 		PowerActivatedSuccessfully() // PAY COST! BEGIN COOLDOWN!

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,22 +436,28 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
-									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 
-		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(16 SECONDS)
-			L.flash_act(1,TRUE)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(1.5 SECONDS)
+				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,28 +436,22 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
-				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
-				C.stuttering += 8
-				C.dizziness += 30
-				C.Jitter(8)
-				C.drop_all_held_items()
-				C.bleed(40)
-				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
-			else
-				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-				L.Paralyze(160)
-				L.flash_act(1,1)
-				if(issilicon(target))
-					var/mob/living/silicon/S = L
-					S.emp_act(EMP_HEAVY)
-				else if(iscarbon(target))
-					var/mob/living/carbon/C = L
-					C.silent += 6
-					C.stuttering += 15
-					C.cultslurring += 15
-					C.Jitter(15)
+		else
+			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+			L.Paralyze(16 SECONDS)
+			L.flash_act(1,TRUE)
+			if(issilicon(target))
+				var/mob/living/silicon/S = L
+				S.emp_act(EMP_HEAVY)
+			else if(iscarbon(target))
+				var/mob/living/carbon/C = L
+				C.silent += 6
+				C.stuttering += 15
+				C.cultslurring += 15
+				C.Jitter(1.5 SECONDS)
 		uses--
 	..()
 

--- a/code/modules/jobs/job_types/shaft_miner.dm
+++ b/code/modules/jobs/job_types/shaft_miner.dm
@@ -1,6 +1,6 @@
 /datum/job/mining
 	title = "Shaft Miner"
-	department_head = list("Head of Personnel")
+	department_head = list("Head of Personnel", "Quartermaster")
 	faction = "Station"
 	total_positions = 3
 	spawn_positions = 3


### PR DESCRIPTION
## About The Pull Request

Since bloodsuckers are back in rotation and still are broken, this is a PR to fix a few gamebreaking bugs since people keep complaining.
1) TRAIT_MUTE is now only given once your Mesmerize ability is complete, which means bloodsuckers can no longer run around purposely failing to mesmerize everyone they want to turn them all into mimes.
2) Shaft Miners now have the Quartermaster as their head, so they will now count towards "Cargo" vassals objective, because they work in Cargo.

## Why It's Good For The Game

Game breaking bug BAD

## Changelog
:cl:
fix: Mesmerize only mutes upon completion.
fix: Shaft Miners now count towards Cargo vassals
/:cl: