### PR TITLE
MHELP and MSAY Mute

### DIFF
--- a/code/modules/mentor_fulp/mentorhelp.dm
+++ b/code/modules/mentor_fulp/mentorhelp.dm
@@ -14,6 +14,11 @@
 	if(!msg)	return
 	if(!mob)	return						//this doesn't happen
 
+	//disables mhelping if ahelp muted
+	if(prefs.muted & MUTE_ADMINHELP)
+		to_chat(src, "<span class='danger'>Error: Admin-PM: You cannot send adminhelps (Muted).</span>", confidential = TRUE)
+	return
+
 	var/show_char = CONFIG_GET(flag/mentors_mobname_only)
 	var/mentor_msg = "<span class='mentornotice'><b><font color='purple'>MENTORHELP:</b> <b>[key_name_mentor(src, 1, 0, 1, show_char)]</b>: [msg]</font></span>"
 	log_mentor("MENTORHELP: [key_name_mentor(src, 0, 0, 0, 0)]: [msg]")

--- a/code/modules/mentor_fulp/mentorsay.dm
+++ b/code/modules/mentor_fulp/mentorsay.dm
@@ -5,6 +5,11 @@
 		to_chat(src, "<span class='danger'>Error: Only mentors and administrators may use this command.</span>", confidential = TRUE)
 		return
 
+	//disables msay if ahelp muted
+	if(prefs.muted & MUTE_ADMINHELP)
+		to_chat(src, "<span class='danger'>Error: Mentor-Say: You cannot send msays (Muted).</span>", confidential = TRUE)
+	return
+
 	msg = emoji_parse(copytext(sanitize(msg), 1, MAX_MESSAGE_LEN))
 	if(!msg)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Gives admins the ability to mute mhelp and msay with ADMINHELP mute in the player panel.

## Why It's Good For The Game
Currently msay and mhelp are the only methods of communication that cannot be muted by admins. Since this is a Fulp exclusive brand of mentor voice, thought I'd chuck this in here rather than create its own button in the player panel.