### PR TITLE
Updated MHELP and MSAY mutes

### DIFF
--- a/code/__DEFINES/admin.dm
+++ b/code/__DEFINES/admin.dm
@@ -6,6 +6,8 @@
 #define MUTE_PRAY		(1<<2)
 #define MUTE_ADMINHELP	(1<<3)
 #define MUTE_DEADCHAT	(1<<4)
+#define MUTE_MSAY		(1<<5)
+#define MUTE_MHELP		(1<<6)
 #define MUTE_ALL		(~0)
 
 //Some constants for DB_Ban

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -98,6 +98,8 @@
 		body += "\[<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_IC]'><font color='[(muted & MUTE_IC)?"red":"blue"]'>IC</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_OOC]'><font color='[(muted & MUTE_OOC)?"red":"blue"]'>OOC</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_PRAY]'><font color='[(muted & MUTE_PRAY)?"red":"blue"]'>PRAY</font></a> | "
+		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_MHELP]'><font color='[(muted & MUTE_MHELP)?"red":"blue"]'>MHELP</font></a> | "
+		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_MSAY]'><font color='[(muted & MUTE_MSAY)?"red":"blue"]'>MSAY</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ADMINHELP]'><font color='[(muted & MUTE_ADMINHELP)?"red":"blue"]'>ADMINHELP</font></a> | "
 		body += "<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_DEADCHAT]'><font color='[(muted & MUTE_DEADCHAT)?"red":"blue"]'>DEADCHAT</font></a>\]"
 		body += "(<A href='?_src_=holder;[HrefToken()];mute=[M.ckey];mute_type=[MUTE_ALL]'><font color='[(muted & MUTE_ALL)?"red":"blue"]'>toggle all</font></a>)"

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -228,6 +228,12 @@
 		if(MUTE_DEADCHAT)
 			mute_string = "deadchat and DSAY"
 			feedback_string = "Deadchat"
+		if(MUTE_MHELP)
+			mute_string = "mhelp"
+			feedback_string = "Mentor Help"
+		if(MUTE_MSAY)
+			mute_string = "msay"
+			feedback_string = "Mentor Say"
 		if(MUTE_ALL)
 			mute_string = "everything"
 			feedback_string = "Everything"

--- a/code/modules/mentor_fulp/mentorhelp.dm
+++ b/code/modules/mentor_fulp/mentorhelp.dm
@@ -10,6 +10,11 @@
 	spawn(300)
 		verbs += /client/verb/mentorhelp	// 30 second cool-down for mentorhelp
 
+	if(usr.client)
+		if(usr.client.prefs.muted & MUTE_MHELP)
+			to_chat(usr, "<span class='danger'>You cannot mhelp (muted).</span>", confidential = TRUE)
+			return
+
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
 	if(!msg)	return
 	if(!mob)	return						//this doesn't happen

--- a/code/modules/mentor_fulp/mentorsay.dm
+++ b/code/modules/mentor_fulp/mentorsay.dm
@@ -5,6 +5,11 @@
 		to_chat(src, "<span class='danger'>Error: Only mentors and administrators may use this command.</span>", confidential = TRUE)
 		return
 
+	if(usr.client)
+		if(usr.client.prefs.muted & MUTE_MSAY)
+			to_chat(usr, "<span class='danger'>You cannot msay (muted).</span>", confidential = TRUE)
+			return
+
 	msg = emoji_parse(copytext(sanitize(msg), 1, MAX_MESSAGE_LEN))
 	if(!msg)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Figured I'd make this less of a bandaid fix and actually go deep and do this properly.  Gives admins the ability to mute mhelp and msay with their own verbs in the player panel, with proper logging. Thanks Wind for the help.

## Why It's Good For The Game

Currently msay and mhelp are the only methods of communication that cannot be muted by admins. This fixes that.

![image](https://user-images.githubusercontent.com/68055775/91674229-fb75bc00-eb8b-11ea-86e8-b22276b999c4.png)
![image](https://user-images.githubusercontent.com/68055775/91674252-17795d80-eb8c-11ea-9a39-c6f225b3895e.png)
![image](https://user-images.githubusercontent.com/68055775/91674269-252ee300-eb8c-11ea-9dd7-d670d40c44a7.png)