### PR TITLE
Cult stun nerf + Zealots gives SecHuds (This time without 70 Commits)

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -137,11 +137,11 @@
 
 
 //Cult Blood Spells
-/datum/action/innate/cult/blood_spell/stun
+/datum/action/innate/cult/blood_spell/stun/fulp
 	name = "Stun"
 	desc = "Empowers your hand to stun and mute a victim on contact."
 	button_icon_state = "hand"
-	magic_path = "/obj/item/melee/blood_magic/stun"
+	magic_path = "/obj/item/melee/blood_magic/stun/fulp"
 	health_cost = 10
 
 /datum/action/innate/cult/blood_spell/teleport

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,22 +436,28 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
-									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
 
-		else
-			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-			L.Paralyze(16 SECONDS)
-			L.flash_act(1,TRUE)
-			if(issilicon(target))
-				var/mob/living/silicon/S = L
-				S.emp_act(EMP_HEAVY)
-			else if(iscarbon(target))
-				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(1.5 SECONDS)
+				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
+				C.stuttering += 8
+				C.dizziness += 30
+				C.Jitter(8)
+				C.drop_all_held_items()
+				C.bleed(40)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -141,7 +141,7 @@
 	name = "Stun"
 	desc = "Empowers your hand to stun and mute a victim on contact."
 	button_icon_state = "hand"
-	magic_path = "/obj/item/melee/blood_magic/stun/fulp"
+	magic_path = "/obj/item/melee/blood_magic/fulpstun"
 	health_cost = 10
 
 /datum/action/innate/cult/blood_spell/teleport

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -436,28 +436,22 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
 			else
-			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 
-				to_chat(user, "<span class='cultitalic'>Their mind was stronger than expected, but you still managed to do some damage!</span>")
-				C.stuttering += 8
-				C.dizziness += 30
-				C.Jitter(8)
-				C.drop_all_held_items()
-				C.bleed(40)
-				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
-			else
-				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
-				L.Paralyze(160)
-				L.flash_act(1,1)
-				if(issilicon(target))
-					var/mob/living/silicon/S = L
-					S.emp_act(EMP_HEAVY)
-				else if(iscarbon(target))
-					var/mob/living/carbon/C = L
-					C.silent += 6
-					C.stuttering += 15
-					C.cultslurring += 15
-					C.Jitter(15)
+		else
+			to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+			L.Paralyze(16 SECONDS)
+			L.flash_act(1,TRUE)
+			if(issilicon(target))
+				var/mob/living/silicon/S = L
+				S.emp_act(EMP_HEAVY)
+			else if(iscarbon(target))
+				var/mob/living/carbon/C = L
+				C.silent += 6
+				C.stuttering += 15
+				C.cultslurring += 15
+				C.Jitter(1.5 SECONDS)
 		uses--
 	..()
 

--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -268,7 +268,7 @@
 	var/list/pickedtype = list()
 	switch(choice)
 		if("Zealot's Blindfold")
-			pickedtype += /obj/item/clothing/glasses/hud/health/night/cultblind
+			pickedtype += /obj/item/clothing/glasses/hud/health/night/fulpcultblind
 		if("Shuttle Curse")
 			pickedtype += /obj/item/shuttle_curse
 		if("Veil Walker Set")

--- a/code/zFulpstationCode/fulp_cult_overwrite.dm
+++ b/code/zFulpstationCode/fulp_cult_overwrite.dm
@@ -1,0 +1,83 @@
+/*
+		Fulpstation Cult Override
+	This was brought to you by the person who has no idea what the hell he's doing, with the help of a few people.
+	Enjoy!
+*/
+
+/datum/action/innate/cult/blood_spell/stun
+	name = "Stun"
+	desc = "Empowers your hand to stun and mute a victim on contact."
+	button_icon_state = "hand"
+	magic_path = "/obj/item/melee/blood_magic/stunfulp"
+	health_cost = 10
+
+/obj/item/melee/blood_magic/stunfulp
+	name = "Stunning Aura"
+	desc = "Will stun and mute a weak-minded victim on contact."
+	color = RUNE_COLOR_RED
+	invocation = "Fuu ma'jin!"
+
+/obj/item/melee/blood_magic/stunfulp/afterattack(atom/target, mob/living/carbon/user, proximity)
+	if(!isliving(target) || !proximity)
+		return
+	var/mob/living/L = target
+	if(iscultist(target))
+		return
+	if(iscultist(user))
+		user.visible_message("<span class='warning'>[user] holds up [user.p_their()] hand, which explodes in a flash of red light!</span>", \
+							"<span class='cultitalic'>You attempt to stun [L] with the spell!</span>")
+
+		user.mob_light(_color = LIGHT_COLOR_BLOOD_MAGIC, _range = 3, _duration = 2)
+
+		var/anti_magic_source = L.anti_magic_check()
+		if(anti_magic_source)
+
+			L.mob_light(_color = LIGHT_COLOR_HOLY_MAGIC, _range = 2, _duration = 100)
+			var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
+			L.add_overlay(forbearance)
+			addtimer(CALLBACK(L, /atom/proc/cut_overlay, forbearance), 100)
+
+			if(istype(anti_magic_source, /obj/item))
+				var/obj/item/ams_object = anti_magic_source
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
+			else
+				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
+
+		else
+			if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
+				var/mob/living/carbon/C = L
+				to_chat(user, "<span class='cultitalic'>Their mind is too strong, resisting the spell, but it did some damage nonetheless!</span>")
+				C.stuttering += 8
+				C.dizziness += 20
+				C.Jitter(6)
+				C.drop_all_held_items()
+				C.bleed(30)
+				C.apply_damage(60, STAMINA, BODY_ZONE_CHEST)
+			else
+				to_chat(user, "<span class='cultitalic'>In a brilliant flash of red, [L] falls to the ground!</span>")
+				L.Paralyze(160)
+				L.flash_act(1,1)
+				if(issilicon(target))
+					var/mob/living/silicon/S = L
+					S.emp_act(EMP_HEAVY)
+				else if(iscarbon(target))
+					var/mob/living/carbon/C = L
+					C.silent += 6
+					C.stuttering += 15
+					C.cultslurring += 15
+					C.Jitter(15)
+		uses--
+	..()
+
+//This is a Fulp-only version of Zealot's blindfold, which comes with SecurityHUDs so Cultists can tell who is Mindshielded.
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind
+	desc = "may Nar'Sie tell you those strong of mind and shield you from the light."
+	name = "zealot's blindfold"
+	icon_state = "blindfold"
+	inhand_icon_state = "blindfold"
+	hud_type = DATA_HUD_SECURITY_ADVANCED
+	hud_trait = TRAIT_SECURITY_HUD
+	flash_protect = FLASH_PROTECTION_FLASH

--- a/code/zFulpstationCode/fulp_cult_overwrite.dm
+++ b/code/zFulpstationCode/fulp_cult_overwrite.dm
@@ -4,20 +4,13 @@
 	Enjoy!
 */
 
-/datum/action/innate/cult/blood_spell/stun
-	name = "Stun"
-	desc = "Empowers your hand to stun and mute a victim on contact."
-	button_icon_state = "hand"
-	magic_path = "/obj/item/melee/blood_magic/stunfulp"
-	health_cost = 10
-
-/obj/item/melee/blood_magic/stunfulp
+/obj/item/melee/blood_magic/fulpstun
 	name = "Stunning Aura"
 	desc = "Will stun and mute a weak-minded victim on contact."
 	color = RUNE_COLOR_RED
 	invocation = "Fuu ma'jin!"
 
-/obj/item/melee/blood_magic/stunfulp/afterattack(atom/target, mob/living/carbon/user, proximity)
+/obj/item/melee/blood_magic/fulpstun/afterattack(atom/target, mob/living/carbon/user, proximity)
 	if(!isliving(target) || !proximity)
 		return
 	var/mob/living/L = target

--- a/code/zFulpstationCode/fulp_cult_overwrite.dm
+++ b/code/zFulpstationCode/fulp_cult_overwrite.dm
@@ -78,6 +78,49 @@
 	name = "zealot's blindfold"
 	icon_state = "blindfold"
 	inhand_icon_state = "blindfold"
-	hud_type = DATA_HUD_SECURITY_ADVANCED
-	hud_trait = TRAIT_SECURITY_HUD
 	flash_protect = FLASH_PROTECTION_FLASH
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind/equipped(mob/living/user, slot)
+	..()
+	if(!iscultist(user))
+		to_chat(user, "<span class='cultlarge'>\"You want to be blind, do you?\"</span>")
+		user.dropItemToGround(src, TRUE)
+		user.Dizzy(30)
+		user.Paralyze(100)
+		user.blind_eyes(30)
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind/Initialize()
+	. = ..()
+	update_icon()
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind/equipped(mob/user, slot)
+	..()
+	add_sensors(user, slot)
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind/dropped(mob/user)
+	..()
+	remove_sensors(user)
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind/proc/add_sensors(mob/user, slot)
+	if(slot != ITEM_SLOT_EYES)
+		return
+	if(!user)
+		if(ismob(loc))
+			user = loc
+		else
+			return
+	var/datum/atom_hud/secsensor = GLOB.huds[DATA_HUD_SECURITY_ADVANCED]
+	var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	secsensor.add_hud_to(user)
+	medsensor.add_hud_to(user)
+
+/obj/item/clothing/glasses/hud/health/night/fulpcultblind/proc/remove_sensors(mob/user)
+	if(!user)
+		if(ismob(loc))
+			user = loc
+		else
+			return
+	var/datum/atom_hud/secsensor = GLOB.huds[DATA_HUD_SECURITY_ADVANCED]
+	var/datum/atom_hud/medsensor = GLOB.huds[DATA_HUD_MEDICAL_ADVANCED]
+	secsensor.remove_hud_from(user)
+	medsensor.remove_hud_from(user)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3454,6 +3454,7 @@
 #include "code\modules\vending\youtool.dm"
 #include "code\modules\zombie\items.dm"
 #include "code\modules\zombie\organs.dm"
+#include "code\zFulpstationCode\fulp_cult_overwrite.dm"
 #include "code\zFulpstationCode\fulp_overwrite_vars.dm"
 #include "code\zFulpstationCode\wizard_spells_disabler.dm"
 #include "interface\interface.dm"


### PR DESCRIPTION
## About The Pull Request

This nerfs the cult's stun ability, causing mindshielded people to drop held items, jitter/stutter, bleed 5% of their blood and take 60 stamina damage (which means 2 consecutive cult stuns will result in stamcrit), while keeping the actual stun for non mindshielded people.
To slightly balance this out we've made a Fulp-only version of the Zealot's blindfold which has Security huds so they can tell who is mindshielded.

## Why It's Good For The Game

The cult stun should be for early game converting and not for winning fights against armed Security Officers lategame.
Also, unless the cult's target is the Chaplain, all it takes is one click to take your target out. This way, even if their target isn't the Chaplain, it still won't just take one click to win.
/tg/ justified that this nerf was bad because "Cult doesn't have security huds", so the blindfold is my compromise
They can also still put you into stamcrit if they use it twice, but that means they're missing another spell they could've had, which at least makes it slightly more balanced.

## Changelog
:cl:
balance: Cult stun causes mindshielded people to jitter rather than stun
balance: Zealot's blindfold gives SecHUDs
/:cl: