### PR TITLE
Adds devils back to event rotation.

### DIFF
--- a/code/modules/events/devil.dm
+++ b/code/modules/events/devil.dm
@@ -1,7 +1,9 @@
 /datum/round_event_control/devil
 	name = "Create Devil"
 	typepath = /datum/round_event/ghost_role/devil
-	max_occurrences = 0
+	max_occurrences = 1
+	weight = 8 // Rarer than Ninjas and blobs, more common than space dragons, seems pretty appropriate.
+	min_players = 40
 
 /datum/round_event/ghost_role/devil
 	var/success_spawn = 0


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin.

## Why It's Good For The Game

Antagonist diversity, we used to have them but I guess they were removed for some reason (from normal rotation), this seeks to re-add them in event form where they can disrupt rounds (but not as much as a space dragon or ninja would), might devote myself to reworking devil if I get a spark of passion to.

## Changelog
:cl:
add: Devils can now appear due to random events, keep your eyes out security.
/:cl:
