### PR TITLE
Deputies can no longer become heretics (on non-dynamic?)

### DIFF
--- a/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
+++ b/code/game/gamemodes/eldritch_cult/eldritch_cult.dm
@@ -4,7 +4,7 @@
 	report_type = "heresy"
 	antag_flag = ROLE_HERETIC
 	false_report_weight = 5
-	protected_jobs = list("Prisoner","Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_jobs = list("Prisoner", "Deputy", "Security Officer", "Warden", "Detective", "Head of Security", "Captain")
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 0
 	required_enemies = 1


### PR DESCRIPTION
## About The Pull Request

Adds deputies to the restricted roles list.

## Why It's Good For The Game

Unintended oversight.

## Changelog
:cl:
fix: Deputies can no longer be heretics.
/:cl:
