### PR TITLE
Adds random job option

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -167,7 +167,6 @@
 
 	if(href_list["SelectedJob"])
 		if(href_list["SelectedJob"] == "Random")
-			//src << browse(null, "window=randjob")
 			var/list/dept_dat = list()
 			for(var/category in GLOB.position_categories)
 				for(var/job in GLOB.position_categories[category]["jobs"])

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -160,7 +160,29 @@
 	if(href_list["manifest"])
 		ViewManifest()
 
+	if(href_list["cancrand"])
+		src << browse(null, "window=randjob") //closes the random job window
+		LateChoices()
+		return
+
 	if(href_list["SelectedJob"])
+		if(href_list["SelectedJob"] == "Random")
+			//src << browse(null, "window=randjob")
+			var/list/dept_dat = list()
+			for(var/category in GLOB.position_categories)
+				for(var/job in GLOB.position_categories[category]["jobs"])
+					var/datum/job/jobs = SSjob.name_occupations[job]
+					if(jobs && IsJobUnavailable(jobs.title, TRUE) == JOB_AVAILABLE)
+						dept_dat += jobs.title
+			var/rando = dept_dat[rand(1, dept_dat.len)]
+			var/randomjob = "<p><center><a href='byond://?src=[REF(src)];SelectedJob=[rando]'>[rando]</a></center><center><a href='byond://?src=[REF(src)];SelectedJob=Random'>Reroll</a></center><center><a href='byond://?src=[REF(src)];cancrand=[1]'>Cancel</a></center></p>"
+
+			var/datum/browser/popup = new(src, "randjob", "<div align='center'>Random Job</div>", 200)
+			popup.set_window_options("can_close=0")
+			popup.set_content(randomjob)
+			popup.open(FALSE)
+			return
+
 		if(!SSticker?.IsRoundInProgress())
 			to_chat(usr, "<span class='danger'>The round is either not ready, or has already finished...</span>")
 			return
@@ -400,6 +422,11 @@
 		column_counter++
 		if(column_counter > 0 && (column_counter % 3 == 0))
 			dat += "</td><td valign='top'>"
+	dat += "<fieldset style='width: 185px; border: 2px solid '#424242'; display: inline'>"
+	dat += "<legend align='center' style='color: '#424242'>Random</legend>"
+	dat += "<a class='job' href='byond://?src=[REF(src)];SelectedJob=Random'>Random</a>"
+	dat += "</fieldset><br>"
+
 	dat += "</td></tr></table></center>"
 	dat += "</div></div>"
 	var/datum/browser/popup = new(src, "latechoices", "Choose Profession", 680, 580)
@@ -491,6 +518,7 @@
 	src << browse(null, "window=preferences") //closes job selection
 	src << browse(null, "window=mob_occupation")
 	src << browse(null, "window=latechoices") //closes late job selection
+	src << browse(null, "window=randjob") //closes the random job window
 
 // Used to make sure that a player has a valid job preference setup, used to knock players out of eligibility for anything if their prefs don't make sense.
 // A "valid job preference setup" in this situation means at least having one job set to low, or not having "return to lobby" enabled


### PR DESCRIPTION
Adds a random job option in the late join job choices.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds a random job option in the late join menu that chooses a random job that is available and lets you either choose it, reroll, or just close it and choose one yourself instead. (This is my first thing made in DM and it was bug tested by me, so make sure to bug test it yourself because I may have missed something.)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

When joining, I always have trouble choosing what job to be, so I always choose the same job. If this option was here, I would get more experience with other jobs. It chooses the job for me.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added a "Random" option in the job choice menu when joining an in-progress round
code: I did not add any actual jobs, just added a choice in the UI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author in-game. -->
<!-- You can use multiple of the same prefix (they're only used for the icon in-game) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
